### PR TITLE
Add missing runtime dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,7 +26,6 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          libgda-mysql-5.0,
          libgda-postgres-5.0
-         
 Pre-Depends: dpkg (>= 1.15.6)
 Description: Sequeler
  Friendly SQL Client

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,11 @@ Build-Depends: cmake (>= 2.8),
 Standards-Version: 3.9.3
 Package: com.github.alecaddd.sequeler
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, 
+         ${shlibs:Depends},
+         libgda-mysql-5.0,
+         libgda-postgres-5.0
+         
 Pre-Depends: dpkg (>= 1.15.6)
 Description: Sequeler
  Friendly SQL Client


### PR DESCRIPTION
Fixes #26 

So the reason why you need your dependencies in three different ways like you were mentioning in the issue is that there are three different things involved here.

The `Build-Depends` list is what's needed to build the package and is used by Houston *only* to download the correct packages (compilers, tools, development versions of libraries, etc...).

The list you provide in your CMake file is not a list of packages, it is a list of `pkg-config` names used by CMake and other build tools to detect if those packages are installed and how to use them. You can see a list of the installed `pkg-config` names by typing `pkg-config` in the terminal and pressing TAB to use tab completion.

Finally, the `Depends` section in `control` is the list of packages that should be installed on a user's computer to run/use the package (i.e. that's usually the non `-dev` versions of the packages in the `Build-Depends` list). However, most packages are common enough that they'd already be installed`${misc:Depends}, ${shlibs:Depends}` are usually enough to automatically pick up most of the deps, so most people don't add anything to here.