### PR TITLE
Revise required granite version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sequeler, is primarly availabe from the AppCenter of elementary OS. Download it 
 ## Install it from source
 You can install Sequeler by compiling from the source, here's the list of dependecies required:
  - `gtk+-3.0>=3.9.10`
- - `granite>=0.4.1`
+ - `granite>=0.5.0`
  - `glib-2.0`
  - `gee-0.8`
  - `gobject-2.0`


### PR DESCRIPTION
Sequeler uses [Granite.MessageDialog](https://valadoc.org/granite/Granite.MessageDialog.html), which appears to have been added in the 0.5 release. This PR updates the README with this requirement.