### PR TITLE
clean the build system

### DIFF
--- a/data/com.github.alecaddd.sequeler.desktop.in
+++ b/data/com.github.alecaddd.sequeler.desktop.in
@@ -1,22 +1,10 @@
 [Desktop Entry]
 Name=Sequeler
 GenericName=Sequeler App
-GenericName[id]=Aplikasi Sequeler
-GenericName[lt]=Sequeler programa
-GenericName[es]=Aplicación Sequeler
-GenericName[de]=Sequeler Programm
-GenericName[pt_BR]=Aplicativo Sequeler
 Comment=Friendly SQL Client
-Comment[id]=SQL Klien yang ramah
-Comment[lt]=Draugiška SQL kliento programa
-Comment[es]=Cliente SQL amigable
-Comment[de]=Freundlicher SQL Client
-Comment[pt_BR]=Cliente SQL amigável
 Categories=Utility;Development;
 Exec=com.github.alecaddd.sequeler
 Icon=com.github.alecaddd.sequeler
 Terminal=false
 Type=Application
-X-GNOME-Gettext-Domain=sequeler
 Keywords=SQL;MySql;Database;MariaDB;S3;PostgreSQL;
-X-GNOME-UsesNotifications=true

--- a/data/meson.build
+++ b/data/meson.build
@@ -3,25 +3,25 @@ icon_sizes = ['16', '24', '32', '48', '64', '128']
 foreach i : icon_sizes
     install_data(
         join_paths('assets/icons', i + 'x' + i, meson.project_name() + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i, 'apps')
+        install_dir: join_paths(get_option('datadir'), 'icons/hicolor', i + 'x' + i, 'apps')
     )
     install_data(
         join_paths('assets/icons', i + 'x' + i, meson.project_name() + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i + '@2', 'apps')
+        install_dir: join_paths(get_option('datadir'), 'icons/hicolor', i + 'x' + i + '@2', 'apps')
     )
 endforeach
 
-# we need to rename these in a post install script because meson doesn't rename things
 foreach i : icon_sizes
     install_data(
         join_paths('assets/icons', i + 'x' + i, meson.project_name() + '.svg'),
-        install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', i + 'x' + i, 'mimetypes')
+        install_dir: join_paths(get_option('datadir'), 'icons/hicolor', i + 'x' + i, 'mimetypes'),
+        rename: 'application-x-sequeler.svg'
     )
 endforeach
 
 install_data(
     'assets/icons/128x128/' + meson.project_name() + '.svg',
-    install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', 'scalable', 'apps')
+    install_dir: join_paths(get_option('datadir'), 'icons/hicolor/scalable/apps')
 )
 
 

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -4,13 +4,16 @@ import os
 import subprocess
 
 install_prefix = os.environ['MESON_INSTALL_PREFIX']
-schemadir = os.path.join(install_prefix, 'share', 'glib-2.0', 'schemas')
+schemadir = os.path.join(install_prefix, 'share/glib-2.0/schemas')
 
 if not os.environ.get('DESTDIR'):
 	print('Compiling gsettings schemas...')
 	subprocess.call(['glib-compile-schemas', schemadir])
-	print('Renaming icons...')
-	for size in ['16x16', '24x24', '32x32', '64x64', '128x128']:
-		src = os.path.join(install_prefix, 'share', 'icons', 'hicolor', size, 'mimetypes', 'com.github.alecaddd.sequeler.svg')
-		dst = os.path.join(install_prefix, 'share', 'icons', 'hicolor', size, 'mimetypes', 'application-x-sequeler.svg')
-		os.rename(src, dst)
+
+	print('Updating icon cache...')
+	icon_cache_dir = os.path.join(install_prefix, 'share/icons/hicolor')
+	subprocess.call(['gtk-update-icon-cache', '-qtf', icon_cache_dir])
+
+	print('Updating desktop database...')
+	desktop_database_dir = os.path.join(install_prefix, 'share/applications')
+	subprocess.call(['update-desktop-database', '-q', desktop_database_dir])

--- a/schemas/meson.build
+++ b/schemas/meson.build
@@ -1,4 +1,4 @@
 install_data(
     meson.project_name() + '.gschema.xml',
-    install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+    install_dir: join_paths(get_option('datadir'), 'glib-2.0/schemas')
 )


### PR DESCRIPTION
This PR does few things:
- Removes the translations from the desktop file. It's already handled by gettext (meson)
- Use rename argument instead fo renaming them using the post_install script
- Refresh the icon cache and reload the desktop files