### PR TITLE
Import the flatpak package file

### DIFF
--- a/com.github.alecaddd.sequeler.json
+++ b/com.github.alecaddd.sequeler.json
@@ -1,0 +1,185 @@
+{
+  "app-id": "com.github.alecaddd.sequeler",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.26",
+  "sdk": "org.gnome.Sdk",
+  "command": "com.github.alecaddd.sequeler",
+  "build-options": {
+    "cflags": "-O2",
+    "cxxflags": "-O2",
+    "env": {
+      "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR": "/app/share/gir-1.0",
+      "PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_TYPELIBDIR": "/app/lib/girepository-1.0"
+    }
+  },
+  "cleanup": [
+    "/bin/granite-demo",
+    "/share/applications/granite-demo.desktop",
+    "/include",
+    "/lib/pkgconfig",
+    "/lib/debug",
+    "/share/vala",
+    "/man",
+    "*.a",
+    "*.la"
+  ],
+  "finish-args": [
+    /* X11 + XShm */
+    "--share=ipc", "--socket=x11",
+    /* Wayland */
+    "--socket=wayland",
+    /* Libsecret BUS */
+    "--talk-name=org.freedesktop.secrets",
+    /* Filesystem*/
+    "--filesystem=home",
+    /* dconf */
+    "--filesystem=xdg-run/dconf", "--filesystem=~/.config/dconf:ro",
+    "--talk-name=ca.desrt.dconf", "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
+    /* access localhost databases */
+    "--share=network"
+  ],
+  "modules": [{
+      "name": "libgee",
+      "sources": [{
+        "type": "archive",
+        "url": "https://github.com/GNOME/libgee/archive/0.20.1.tar.gz",
+        "sha256": "d76d0bf8ae6659dba6018fadf2ccce218ccbc107666925552008806a29702c4b"
+      }]
+    },
+    {
+      "name": "granite",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release"
+      ],
+      "sources": [{
+        "type": "archive",
+        "url": "https://github.com/elementary/granite/archive/0.5.tar.gz",
+        "sha256": "cc4905ae70fddeba3d2ded44bb642be77d419aa090251a7ab24c155b8616be06"
+      }]
+    },
+    {
+      "name": "libxml2",
+      "build-options": {
+        "config-opts": [
+          "--with-python=no"
+        ]
+      },
+      "sources": [{
+        "type": "archive",
+        "url": "https://github.com/GNOME/libxml2/archive/v2.9.8.tar.gz",
+        "sha256": "ff879b0d9142564bfe63df9753df936f05150afdd7bae07261f12d4dad33ba4a"
+      }]
+    },
+    {
+      "name": "gtksourceview",
+      "build-options": {
+        "config-opts": [
+          "--enable-gtk-doc=no"
+        ]
+      },
+      "sources": [{
+        "type": "archive",
+        "url": "https://download.gnome.org/sources/gtksourceview/3.24/gtksourceview-3.24.6.tar.xz",
+        "sha256": "7aa6bdfebcdc73a763dddeaa42f190c40835e6f8495bb9eb8f78587e2577c188"
+      }]
+    },
+    {
+      "name": "postgresql-libs",
+      "build-options": {
+        "config-opts": [
+          "--with-python=no",
+          "--with-perl=no",
+          "--with-libxml",
+          "--with-openssl",
+          "--with-tcl"
+        ]
+      },
+      "sources": [{
+        "type": "archive",
+        "url": "https://ftp.postgresql.org/pub/source/v10.3/postgresql-10.3.tar.bz2",
+        "sha256": "6ea268780ee35e88c65cdb0af7955ad90b7d0ef34573867f223f14e43467931a"
+      }]
+    },
+    {
+      "name": "jemalloc",
+      "cleanup": [
+        "/bin/",
+        "/share"
+      ],
+      "sources": [{
+        "type": "archive",
+        "url": "https://github.com/jemalloc/jemalloc/releases/download/4.5.0/jemalloc-4.5.0.tar.bz2",
+        "sha256": "9409d85664b4f135b77518b0b118c549009dc10f6cba14557d170476611f6780"
+      }]
+    },
+    {
+      "name": "libaio",
+      "buildsystem": "simple",
+      "build-commands": [
+        "make",
+        "make prefix=/app install"
+      ],
+      "sources": [{
+        "type": "archive",
+        "url": "http://ftp.de.debian.org/debian/pool/main/liba/libaio/libaio_0.3.110.orig.tar.gz",
+        "sha256": "e019028e631725729376250e32b473012f7cb68e1f7275bfc1bbcdd0f8745f7e"
+      }]
+    },
+    {
+      "name": "mariadb",
+      "buildsystem": "cmake",
+      "no-make-install": true,
+      "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_CONFIG=mysql_release",
+        "-DWITH_INNOBASE_STORAGE_ENGINE=1",
+        "-DWITHOUT_ARCHIVE_STORAGE_ENGINE=1",
+        "-DWITHOUT_BLACKHOLE_STORAGE_ENGINE=1",
+        "-DWITHOUT_PARTITION_STORAGE_ENGINE=1",
+        "-DWITHOUT_TOKUDB=1",
+        "-DWITHOUT_EXAMPLE_STORAGE_ENGINE=1",
+        "-DWITHOUT_FEDERATED_STORAGE_ENGINE=1",
+        "-DWITHOUT_PBXT_STORAGE_ENGINE=1"
+      ],
+      "post-install": [
+        "make -C libmysql install",
+        "make -C include install",
+        "install -Dm755 scripts/mysql_config /app/bin/mysql_config",
+        "install -Dm644 support-files/mariadb.pc /app/share/pkgconfig/mariadb.pc"
+      ],
+      "cleanup": [
+        "/bin/"
+      ],
+      "sources": [{
+        "type": "archive",
+        "url": "http://ftp.hosteurope.de/mirror/archive.mariadb.org/mariadb-10.1.24/source/mariadb-10.1.24.tar.gz",
+        "sha256": "b3df99ae5b1ec8cf6cede4cbc4ae3f54ce66464549cba6d56d9ff4d24e4d551e"
+      }]
+    },
+    {
+      "name": "libgda",
+      "build-options": {
+        "config-opts": [
+          "--with-java=no",
+          "--with-jni=no",
+          "--with-oracle=no"
+        ]
+      },
+      "sources": [{
+        "type": "archive",
+        "url": "https://github.com/GNOME/libgda/archive/LIBGDA_5_2_4.tar.gz",
+        "sha256": "cd3bf74ead03dc1715f51463a9e4864d55b9bdcffb732dc88095dbd919a67180"
+      }]
+    },
+    {
+      "name": "sequeler",
+      "buildsystem": "meson",
+      "config-opts": ["--buildtype=release"],
+      "sources": [{
+        "type": "git",
+        "url": "https://github.com/Alecaddd/sequeler.git"
+      }]
+    }
+  ]
+}


### PR DESCRIPTION
This will allow users to run GNOME Builder, clone the repo and click on run. The application will be built automatically from master.
To make the app development and the contributions pretty simple for guys who uses Builder!

I can maintain this, the same way I maintain the flatpak package on Flathub.