### PR TITLE
Fixes for ssh tunneling

### DIFF
--- a/com.github.alecaddd.sequeler.json
+++ b/com.github.alecaddd.sequeler.json
@@ -1,7 +1,7 @@
 {
   "app-id": "com.github.alecaddd.sequeler",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.26",
+  "runtime-version": "3.28",
   "sdk": "org.gnome.Sdk",
   "command": "com.github.alecaddd.sequeler",
   "build-options": {
@@ -54,8 +54,8 @@
       ],
       "sources": [{
         "type": "archive",
-        "url": "https://github.com/elementary/granite/archive/0.5.tar.gz",
-        "sha256": "cc4905ae70fddeba3d2ded44bb642be77d419aa090251a7ab24c155b8616be06"
+        "url": "https://github.com/elementary/granite/archive/5.2.1.tar.gz",
+        "sha256": "2166902654f62d300c6990d634f494632aaf14dfe10395dd9ff9d52a503c7ca8"
       }]
     },
     {
@@ -171,6 +171,39 @@
         "url": "https://github.com/GNOME/libgda/archive/LIBGDA_5_2_4.tar.gz",
         "sha256": "cd3bf74ead03dc1715f51463a9e4864d55b9bdcffb732dc88095dbd919a67180"
       }]
+    },
+    {
+      "name": "libfixposix",
+      "buildsystem":"simple",
+      "build-commands": [
+        "autoreconf -i -f",
+        "./configure",
+        "make",
+        "make prefix=/app install"
+      ],
+      "sources": [{
+        "type": "git",
+        "url": "https://github.com/sionescu/libfixposix"
+      }]
+    },
+    {
+            "name" : "libssh2",
+            "buildsystem" : "cmake-ninja",
+            "config-opts" : [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DCMAKE_INSTALL_LIBDIR:PATH=/app/lib",
+                "-DBUILD_SHARED_LIBS:BOOL=ON"
+            ],
+            "cleanup" : [
+                "/share/doc"
+            ],
+            "sources" : [
+                {
+                    "type" : "git",
+                    "url" : "https://github.com/libssh2/libssh2.git",
+                    "branch" : "libssh2-1.8.0"
+                }
+            ]
     },
     {
       "name": "sequeler",

--- a/src/Services/ConnectionManager.vala
+++ b/src/Services/ConnectionManager.vala
@@ -117,6 +117,7 @@ public class Sequeler.Services.ConnectionManager : Object {
 
 		var ssh_host = Posix.inet_addr (data["ssh_host"]);
 		var ssh_username = data["ssh_username"];
+		var ssh_password = data["ssh_password"];
 		var ssh_port = data["ssh_port"] != "" ? (uint16) (data["ssh_port"]).hash () : 22;
 		var host = data["host"] != "" ? data["host"] : "127.0.0.1";
 		var host_port = data["port"] != "" ? int.parse (data["port"]) : 3307;
@@ -154,7 +155,7 @@ public class Sequeler.Services.ConnectionManager : Object {
 		}
 
 		if (auth_key) {
-			if (session.auth_publickey_from_file (ssh_username, keyfile1, keyfile2, null) != SSH2.Error.NONE) {
+			if (session.auth_publickey_from_file (ssh_username, keyfile1, keyfile2, ssh_password) != SSH2.Error.NONE) {
 				ssh_tunnel_close ();
 				throw new Error.literal (q, 1, _("Error! Public Key doesn't match."));
 			}


### PR DESCRIPTION
Several fixes to make dev branch to work with flatpak

I think the way to go for ssh tunnel is to mimic:

https://github.com/marianafranco/libssh2-tunnel-example/blob/master/libssh2-tunnel-example.c

which actually works:

```
$ git clone https://github.com/marianafranco/libssh2-tunnel-example
$ cd libssh2-tunnel-example
$ make
$ python2 -m SimpleHTTPServer 8080 &
$ ./libssh2-tunnel-example 127.0.0.1 <user> <password> &
$ curl 127.0.0.1:4000
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN"><html>
<title>Directory listing for /</title>
<body>
<h2>Directory listing for /</h2>
<hr>
<ul>
<li><a href=".git/">.git/</a>
<li><a href="libssh2-tunnel-example">libssh2-tunnel-example</a>
<li><a href="libssh2-tunnel-example.c">libssh2-tunnel-example.c</a>
<li><a href="LICENSE.md">LICENSE.md</a>
<li><a href="Makefile">Makefile</a>
<li><a href="README.md">README.md</a>
</ul>
<hr>
</body>
</html>
```

I create a local tunnel for mariadb

    ssh -L 9000:127.0.0.1:3306 <user>@127.0.0.1

and sequeler connects correctly to port 9000

so I think what is missing here is the while(1) where bits are read and write (actually doing the forwarding)

https://github.com/marianafranco/libssh2-tunnel-example/blob/master/libssh2-tunnel-example.c#L87
