### PR TITLE
Add a launchable tag to the appdata file

### DIFF
--- a/data/com.github.alecaddd.sequeler.appdata.xml.in
+++ b/data/com.github.alecaddd.sequeler.appdata.xml.in
@@ -298,6 +298,7 @@
     </screenshot>
   </screenshots>
   <developer_name>Alessandro Castellani</developer_name>
+  <launchable type="desktop-id">com.github.alecaddd.sequeler.desktop</launchable>
   <url type="homepage">https://github.com/Alecaddd/sequeler</url>
   <url type="bugtracker">https://github.com/Alecaddd/sequeler/issues</url>
   <url type="help">https://github.com/Alecaddd/sequeler/issues</url>
@@ -336,4 +337,9 @@
     <value key="x-appcenter-color-primary-text">#ffffff</value>
     <value key="x-appcenter-suggested-price">15</value>
   </custom>
+  <kudos>
+    <kudo>HiDpiIcon</kudo>
+    <kudo>HighContrast</kudo>
+    <kudo>ModernToolkit</kudo>
+  </kudos>
 </component>

--- a/data/com.github.alecaddd.sequeler.appdata.xml.in
+++ b/data/com.github.alecaddd.sequeler.appdata.xml.in
@@ -300,6 +300,7 @@
   <developer_name>Alessandro Castellani</developer_name>
   <launchable type="desktop-id">com.github.alecaddd.sequeler.desktop</launchable>
   <url type="homepage">https://github.com/Alecaddd/sequeler</url>
+  <url type="donation">https://www.paypal.me/alecaddd</url>
   <url type="bugtracker">https://github.com/Alecaddd/sequeler/issues</url>
   <url type="help">https://github.com/Alecaddd/sequeler/issues</url>
   <update_contact>castellani.ale@gmail.com</update_contact>


### PR DESCRIPTION
Per the specs: https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html
It allows Software Center's to launch the app and it's used to merge the info from both files into one during the build of the app.
Also add kudos for GNOME Software.