### PR TITLE
Fixing flatpak

### DIFF
--- a/com.github.alecaddd.sequeler.json
+++ b/com.github.alecaddd.sequeler.json
@@ -28,30 +28,7 @@
     /* access localhost databases */
     "--share=network"
   ],
-<<<<<<< HEAD
-  "modules": [{
-      "name": "libgee",
-      "sources": [{
-        "type": "archive",
-        "url": "https://github.com/GNOME/libgee/archive/0.20.1.tar.gz",
-        "sha256": "d76d0bf8ae6659dba6018fadf2ccce218ccbc107666925552008806a29702c4b"
-      }]
-    },
-    {
-      "name": "granite",
-      "buildsystem": "cmake-ninja",
-      "config-opts": [
-        "-DCMAKE_BUILD_TYPE=Release"
-      ],
-      "sources": [{
-        "type": "archive",
-        "url": "https://github.com/elementary/granite/archive/5.2.1.tar.gz",
-        "sha256": "2166902654f62d300c6990d634f494632aaf14dfe10395dd9ff9d52a503c7ca8"
-      }]
-    },
-=======
   "modules": [
->>>>>>> master
     {
       "name": "libxml2",
       "build-options": {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -90,6 +90,8 @@ public class Sequeler.Application : Gtk.Application {
 
     protected override void activate () {
         var window = new Sequeler.Window (this);
+        Gtk.Settings.get_default().set_property("gtk-theme-name", "elementary");
+        Gtk.Settings.get_default().set_property("gtk-icon-theme-name", "elementary");
         this.add_window (window);
     }
 }

--- a/src/Layouts/DataBaseSchema.vala
+++ b/src/Layouts/DataBaseSchema.vala
@@ -339,7 +339,18 @@ public class Sequeler.Layouts.DataBaseSchema : Gtk.Grid {
 
 		toolbar_spinner.start ();
 
-		window.main.connection_manager.connection.close ();
+		var connection_manager = window.main.connection_manager;
+
+		//if (connection_manager.data["has_ssh"] == "true") {
+	//		connection_manager.ssh_tunnel_close ("DataBaseSchema:377");
+	//	}
+
+		if (connection_manager.connection.is_opened ()) {
+			connection_manager.connection.clear_events_list ();
+			connection_manager.connection.close ();
+			connection_manager.connection = null;
+		}
+
 		var new_connection_manager = new Sequeler.Services.ConnectionManager (window, window.data_manager.data);
 
 		var loop = new MainLoop ();

--- a/src/Layouts/Main.vala
+++ b/src/Layouts/Main.vala
@@ -89,7 +89,7 @@ public class Sequeler.Layouts.Main : Gtk.Paned {
 
 	public void connection_closed () {
 		if (connection_manager.data["has_ssh"] == "true") {
-			connection_manager.ssh_tunnel_close (-1, -1, -1, "Main:88");
+			connection_manager.ssh_tunnel_close ("Main:88");
 		}
 
 		if (connection_manager.connection.is_opened ()) {

--- a/src/Services/ConnectionManager.vala
+++ b/src/Services/ConnectionManager.vala
@@ -35,6 +35,10 @@ public class Sequeler.Services.ConnectionManager : Object {
 	public Gda.DataModel? output_select;
 
 	public SSH2.Session session;
+	int sock;
+	int listensock;
+	int forwardsock;
+	bool ssh_tunnel_alive = false;
 
 	enum Auth {
 		NONE,
@@ -134,8 +138,10 @@ public class Sequeler.Services.ConnectionManager : Object {
 	}
 
 	private void ssh_tunnel_open (bool is_real) throws Error {
-		debug ("Opening tunnel");
-		
+		debug ("Opening tunnel %p", Thread.self<bool> ());
+
+		ssh_tunnel_alive = true;
+
 		Quark q = Quark.from_string ("ssh-error-str");
 		var home_dir = Environment.get_home_dir ();
 		var keyfile1 = home_dir + "/.ssh/id_rsa.pub";
@@ -208,7 +214,7 @@ public class Sequeler.Services.ConnectionManager : Object {
 		if ((auth_pw & Auth.PASSWORD) != 0) {
 			if (session.auth_password (username, password) != SSH2.Error.NONE) {
 				debug ("Authentication by password failed.");
-				ssh_tunnel_close (sock, -1, -1, Log.FILE + ":" + Log.LINE.to_string ());
+				ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 				throw new Error.literal (q, 1, _("Authentication by password failed!"));
 			}
 		} else if ((auth_pw & Auth.PUBLICKEY) != 0) {
@@ -218,21 +224,21 @@ public class Sequeler.Services.ConnectionManager : Object {
 												password
 											) != SSH2.Error.NONE) {
 				debug ("Authentication by public key failed!");
-				ssh_tunnel_close (sock, -1, -1, Log.FILE + ":" + Log.LINE.to_string ());
+				ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 				throw new Error.literal (q, 1, _("Authentication by public key failed!"));
 			}
 
 			debug ("Authentication by public key succeeded.");
 		} else {
 			debug ("No supported authentication methods found!");
-			ssh_tunnel_close (sock, -1, -1, Log.FILE + ":" + Log.LINE.to_string ());
+			ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 			throw new Error.literal (q, 1, _("No supported authentication methods found!"));
 		}
 
-		var listensock = Posix.socket (Posix.AF_INET, Posix.SOCK_STREAM, Posix.IPProto.TCP);
+		listensock = Posix.socket (Posix.AF_INET, Posix.SOCK_STREAM, Posix.IPProto.TCP);
 		if (listensock == -1) {
 			debug ("failed to open listen socket");
-			ssh_tunnel_close (sock, listensock, -1, Log.FILE + ":" + Log.LINE.to_string ());
+			ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 			throw new Error.literal (q, 1, _("Failed to open listen socket"));
 		}
 
@@ -247,40 +253,40 @@ public class Sequeler.Services.ConnectionManager : Object {
 		Posix.setsockopt (listensock, Linux.Socket.SOL_SOCKET, Linux.Socket.SO_REUSEADDR, &sockopt, (Posix.socklen_t) sizeof (int)); 
 		if (Posix.bind (listensock, &sin, sizeof (Posix.SockAddrIn)) == -1) {
 			debug ("Failed to bind!");
-			ssh_tunnel_close (sock, listensock, -1, Log.FILE + ":" + Log.LINE.to_string ());
+			ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 			throw new Error.literal (q, 1, _("Failed to bind. Your Database Port may be wrong!"));
 		}
 
 		if (Posix.listen (listensock, 2) == -1) {
 			debug ("Failed to listen!");
-			ssh_tunnel_close (sock, listensock, -1, Log.FILE + ":" + Log.LINE.to_string ());
+			ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 			throw new Error.literal (q, 1, _("Failed to listen!"));
 		}
 
 		debug ("Waiting for TCP connection on %s:%d...", local_listenip, local_listenport);
 
 		bool signal_launched = false;
-		while (true) {
+		while (ssh_tunnel_alive) {
 
 			if (!signal_launched) {
 				signal_launched = true;
 				ssh_tunnel_ready ();
 			} else {
 				if (!is_real) {
-					ssh_tunnel_close (sock, listensock, -1, Log.FILE + ":" + Log.LINE.to_string ());
+					ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 					return;
 				}
 			}
 
-			debug ("Waiting for remote connection");
+			debug ("Waiting for remote connection %p", Thread.self<bool> ());
 
-			var forwardsock = Posix.accept (listensock, null, null);
+			forwardsock = Posix.accept (listensock, null, null);
 
 			debug ("forwardsock %d", forwardsock);
 
 			if (forwardsock == -1) {
 				debug ("Failed to accept!");
-				ssh_tunnel_close (sock, listensock, forwardsock, Log.FILE + ":" + Log.LINE.to_string ());
+				ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 				throw new Error.literal (q, 1, _("Failed to accept remote connection!"));
 			}
 
@@ -289,14 +295,14 @@ public class Sequeler.Services.ConnectionManager : Object {
 			var channel = session.direct_tcpip (remote_desthost, remote_destport, local_listenip, local_listenport);
 			if (channel == null) {
 				debug ("Could not open the direct-tcpip channel! (Note that this can be a problem at the server! Please review the server logs.)");
-				ssh_tunnel_close (sock, listensock, forwardsock, Log.FILE + ":" + Log.LINE.to_string ());
+				ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 				throw new Error.literal (q, 1, _("Could not open the direct-tcpip channel! (Note that this can be a problem at the server! Please review the server logs.)"));
 			}
 
 			session.blocking = false;
 
 			uint8[] buf = new uint8[16384];
-			while (true) {
+			while (ssh_tunnel_alive) {
 				Posix.fd_set fds;
 				Posix.FD_ZERO (out fds);
 				Posix.FD_SET (forwardsock, ref fds);
@@ -305,7 +311,7 @@ public class Sequeler.Services.ConnectionManager : Object {
 
 				if (-1 == res) {
 					debug ("Error on select!");
-					direct_shutdown(forwardsock);
+					direct_shutdown ();
 					break;
 				}
 
@@ -313,11 +319,11 @@ public class Sequeler.Services.ConnectionManager : Object {
 					var len = Posix.recv (forwardsock, buf, 16384, 0);
 					if (len < 0) {
 						debug ("Error reading from the forwardsock!");
-						direct_shutdown(forwardsock);
+						direct_shutdown ();
 						break;
 					} else if (0 == len) {
 						debug ("The client at %s:%d disconnected!", local_listenip, local_listenport);
-						direct_shutdown(forwardsock);
+						direct_shutdown ();
 						break;
 					}
 					ssize_t wr = 0;
@@ -326,7 +332,7 @@ public class Sequeler.Services.ConnectionManager : Object {
 						i = channel.write (buf[0:len]);
 						if (i < 0) {
 							debug ("Error writing on the SSH channel: %s", i.to_string ());
-							direct_shutdown(forwardsock);
+							direct_shutdown ();
 							break;
 						}
 						wr += i;
@@ -339,7 +345,7 @@ public class Sequeler.Services.ConnectionManager : Object {
 						break;
 					else if (len < 0) {
 						debug ("Error reading from the SSH channel: %d", (int) len);
-						direct_shutdown(forwardsock);
+						direct_shutdown ();
 						break;
 					}
 					ssize_t wr = 0;
@@ -347,14 +353,14 @@ public class Sequeler.Services.ConnectionManager : Object {
 						ssize_t i = Posix.send (forwardsock, buf[wr:buf.length], len - wr, 0);
 						if (i <= 0) {
 							debug ("Error writing on the forwardsock!");
-							direct_shutdown(forwardsock);
+							direct_shutdown ();
 							break;
 						}
 						wr += i;
 					}
 					if (channel.eof () != SSH2.Error.NONE) {
 						debug ("The remote client at %s:%d disconnected!", remote_desthost, remote_destport);
-						direct_shutdown(forwardsock);
+						direct_shutdown ();
 						break;
 					}
 				}
@@ -362,23 +368,34 @@ public class Sequeler.Services.ConnectionManager : Object {
 		}
 	}
 
-	public void ssh_tunnel_close (int sock, int listensock, int forwardsock, string from = "Unknown") {
-		debug ("closing ssh tunnel from: %s", from);
+	public void ssh_tunnel_close (string from = "Unknown") {
+		debug ("closing ssh tunnel from: %s %p", from, Thread.self<bool> ());
+		ssh_tunnel_alive = false;
 
+		debug ("closing listensock: %d", listensock);
 		Posix.close (listensock);
+		listensock = -1;
+		debug ("listensock closed: %d", listensock);
+		debug ("closing forwardsock: %d", forwardsock);
 		Posix.close (forwardsock);
+		forwardsock = -1;
+		debug ("forwardsock closed: %d", forwardsock);
 
 		if (session != null) {
-	   		session.disconnect ("Client disconnecting normally");
+			session.disconnect ("Client disconnecting normally");
+			session.blocking = false;
+			session = null;
 		}
 
 		Posix.close (sock);
+		sock = -1;
 		SSH2.exit ();
 	}
 
-	public void direct_shutdown (int forwardsock) {
+	public void direct_shutdown () {
 		session.blocking = true;
 		Posix.close (forwardsock);
+		forwardsock = -1;
 	}
 
 	public int run_query (string query) throws Error requires (connection.is_opened ()) {
@@ -478,13 +495,13 @@ public class Sequeler.Services.ConnectionManager : Object {
 	public void query_warning (string message) {
 		var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (_("Error!"), message, "dialog-error", Gtk.ButtonsType.NONE);
 		message_dialog.transient_for = window;
-		
+
 		var suggested_button = new Gtk.Button.with_label ("Close");
 		message_dialog.add_action_widget (suggested_button, Gtk.ResponseType.ACCEPT);
 
 		message_dialog.show_all ();
 		if (message_dialog.run () == Gtk.ResponseType.ACCEPT) {}
-		
+
 		message_dialog.destroy ();
 	}
 }

--- a/src/Widgets/ConnectionDialog.vala
+++ b/src/Widgets/ConnectionDialog.vala
@@ -48,11 +48,9 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 	private Sequeler.Partials.Entry db_password_entry;
 	private Sequeler.Partials.Entry db_port_entry;
 	private Gtk.FileChooserButton db_file_entry;
-	private Gtk.Separator db_separator;
 
 	private string keyfile1;
 	private string keyfile2;
-	private Gtk.Separator ssh_separator;
 	private Sequeler.Partials.LabelForm ssh_switch_label;
 	private Gtk.Grid ssh_switch_container;
 	private Gtk.Switch ssh_switch;
@@ -183,10 +181,15 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 		form_grid.attach (db_host_label, 0, 2, 1, 1);
 		form_grid.attach (db_host_entry, 1, 2, 1, 1);
 
-		db_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
-		db_separator.margin_top = 10;
-		db_separator.margin_bottom = 10;
-		form_grid.attach (db_separator, 0, 3, 2, 1);
+		var expander = new Gtk.Expander ("Database");
+		expander.set_expanded (true);
+
+		expander.add (form_grid);
+		body.add (expander);
+		form_grid = new Gtk.Grid ();
+		form_grid.margin = 30;
+		form_grid.row_spacing = 10;
+		form_grid.column_spacing = 20;
 
 		db_name_label = new Sequeler.Partials.LabelForm (_("Database Name:"));
 		db_name_entry = new Sequeler.Partials.Entry ("", null);
@@ -209,7 +212,7 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 			if (pos == Gtk.EntryIconPosition.SECONDARY) {
 				db_password_entry.visibility = !db_password_entry.visibility;
 			}
- 			if (db_password_entry.visibility) {
+			if (db_password_entry.visibility) {
 				db_password_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "changes-allow-symbolic");
 			} else {
 				db_password_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "changes-prevent-symbolic");
@@ -243,10 +246,15 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 		db_file_entry.visible = false;
 		db_file_entry.no_show_all = true;
 
-		ssh_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
-		ssh_separator.margin_top = 10;
-		ssh_separator.margin_bottom = 10;
-		form_grid.attach (ssh_separator, 0, 9, 2, 1);
+		expander = new Gtk.Expander ("Properties");
+		expander.set_expanded (true);
+
+		expander.add (form_grid);
+		body.add (expander);
+		form_grid = new Gtk.Grid ();
+		form_grid.margin = 30;
+		form_grid.row_spacing = 10;
+		form_grid.column_spacing = 20;
 
 		ssh_switch = new Gtk.Switch ();
 		ssh_switch_container = new Gtk.Grid ();
@@ -264,7 +272,7 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 		ssh_host_entry = new Sequeler.Partials.Entry ("", null);
 		form_grid.attach (ssh_host_label, 0, 11, 1, 1);
 		form_grid.attach (ssh_host_entry, 1, 11, 1, 1);
-		
+
 		ssh_username_label = new Sequeler.Partials.LabelForm (_("SSH Username:"));;
 		ssh_username_entry = new Sequeler.Partials.Entry ("", null);
 		form_grid.attach (ssh_username_label, 0, 12, 1, 1);
@@ -286,7 +294,7 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 		});
 		form_grid.attach (ssh_password_label, 0, 13, 1, 1);
 		form_grid.attach (ssh_password_entry, 1, 13, 1, 1);
-		
+
 		ssh_port_label = new Sequeler.Partials.LabelForm (_("SSH Port:"));;
 		ssh_port_entry = new Sequeler.Partials.Entry (_("Optional"), null);
 		form_grid.attach (ssh_port_label, 0, 14, 1, 1);
@@ -307,12 +315,22 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 			if (response == 0) {
 				try {
 					ssh_switch.active = false;
-                    AppInfo.launch_default_for_uri ("https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/", null);
-                } catch (Error e) {
-                    warning ("%s\n", e.message);
-                }
+						AppInfo.launch_default_for_uri ("https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/", null);
+					} catch (Error e) {
+						warning ("%s\n", e.message);
+					}
 			}
 		});
+
+		expander = new Gtk.Expander ("SSH properties");
+
+		expander.add (form_grid);
+		body.add (expander);
+
+		form_grid = new Gtk.Grid ();
+		form_grid.margin = 30;
+		form_grid.row_spacing = 10;
+		form_grid.column_spacing = 20;
 
 		form_grid.attach (infobar, 0, 15, 2, 1);
 
@@ -446,7 +464,7 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 			ssh_loop.run ();
 
 			ssh_switch.active = bool.parse (update_data["has_ssh"]);
-			
+
 			ssh_host_entry.text = (update_data["ssh_host"] != null) ? update_data["ssh_host"] : "";
 			ssh_username_entry.text = (update_data["ssh_username"] != null) ? update_data["ssh_username"] : "";
 			ssh_password_entry.text = (old_ssh_password != null) ? old_ssh_password : "";
@@ -493,13 +511,8 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 		db_port_entry.visible = !toggle;
 		db_port_entry.no_show_all = toggle;
 
-		db_separator.visible = !toggle;
-		db_separator.no_show_all = toggle;
-
 		if (toggle) ssh_switch.active = false;
 
-		ssh_separator.visible = !toggle;
-		ssh_separator.no_show_all = toggle;
 		ssh_switch_container.visible = !toggle;
 		ssh_switch_container.no_show_all = toggle;
 		ssh_switch_label.visible = !toggle;
@@ -568,7 +581,7 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 		}
 
 		SourceFunc callback = open_ssh_connection.callback;
-		
+
 		new Thread <void*> (null, () => {
 			try {
 				connection_manager.ssh_tunnel_init (is_real);

--- a/src/Widgets/ConnectionDialog.vala
+++ b/src/Widgets/ConnectionDialog.vala
@@ -544,7 +544,7 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 				break;
 			case Action.CANCEL:
 				if (connection_manager != null) {
-					connection_manager.ssh_tunnel_close (-1, -1, -1, Log.FILE + ":" + Log.LINE.to_string ());
+					connection_manager.ssh_tunnel_close (Log.FILE + ":" + Log.LINE.to_string ());
 				}
 				destroy ();
 				break;


### PR DESCRIPTION
Taking flathub as example I fixed flatpak compilation to check under an elementary sandbox

I did install org.gnome.Sdk.Debug and get backtraces like:

<details>
<summary>backtrace</summary>

```
Thread 1 "com.github.alec" received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x00007ffff784c470 in gtk_css_value_border_compute (value=0x5555556ce580, property_id=58, provider=0x7fffec003990, style=0x555555f70370, parent_style=0x555555f73480)
    at gtkcssbordervalue.c:60
#2  0x00007ffff7874938 in gtk_css_static_style_compute_value (style=0x555555f70370, provider=0x7fffec003990, parent_style=0x555555f73480, id=58, 
    specified=0x7ffff7e16b30 <initial>, section=0x0) at gtkcssstaticstyle.c:237
#3  0x00007ffff785fc82 in _gtk_css_lookup_resolve (lookup=lookup@entry=0x555555ed9000, provider=provider@entry=0x7fffec003990, style=style@entry=0x555555f70370, 
    parent_style=parent_style@entry=0x555555f73480) at gtkcsslookup.c:122
#4  0x00007ffff7874860 in gtk_css_static_style_new_compute (provider=0x7fffec003990, matcher=matcher@entry=0x7fffffffb190, parent=parent@entry=0x555555f73480)
    at gtkcssstaticstyle.c:195
#5  0x00007ffff78622e5 in gtk_css_node_create_style (cssnode=0x7fffdc013e10) at gtkcssnode.c:371
#6  gtk_css_node_real_update_style (cssnode=0x7fffdc013e10, change=64424509425, timestamp=41135048752, style=0x555555f745b0) at gtkcssnode.c:425
#7  0x00007ffff7861094 in gtk_css_node_ensure_style (cssnode=cssnode@entry=0x7fffdc013e10, current_time=41135048752) at gtkcssnode.c:1007
#8  0x00007ffff786127e in gtk_css_node_ensure_style (current_time=<optimized out>, cssnode=0x7fffdc013e10) at gtkcssnode.c:1033
#9  gtk_css_node_get_style (cssnode=0x7fffdc013e10) at gtkcssnode.c:1033
#10 0x00007ffff7853059 in gtk_css_gadget_get_style (gadget=0x7fffdc013f70) at gtkcssgadget.c:645
#11 gtk_css_gadget_get_preferred_size (gadget=0x7fffdc013f70, orientation=orientation@entry=GTK_ORIENTATION_VERTICAL, for_size=for_size@entry=-1, 
    minimum=minimum@entry=0x7fffffffb3b8, natural=natural@entry=0x7fffffffb3bc, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtkcssgadget.c:645
#12 0x00007ffff7975853 in gtk_range_size_request (widget=0x555555e59170, orientation=GTK_ORIENTATION_VERTICAL, minimum=0x7fffffffb3b8, natural=0x7fffffffb3bc)
    at gtkrange.c:1909
#13 0x00007ffff79b2fcb in gtk_widget_query_size_for_orientation (widget=widget@entry=0x555555e59170, orientation=orientation@entry=GTK_ORIENTATION_VERTICAL, 
    for_size=for_size@entry=-1, minimum_size=minimum_size@entry=0x7fffffffb540, natural_size=natural_size@entry=0x7fffffffb544, 
    minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtksizerequest.c:219
#14 0x00007ffff79b3730 in gtk_widget_compute_size_for_orientation (widget=widget@entry=0x555555e59170, orientation=orientation@entry=GTK_ORIENTATION_VERTICAL, 
    for_size=for_size@entry=-1, minimum=minimum@entry=0x7fffffffb540, natural=natural@entry=0x7fffffffb544, minimum_baseline=minimum_baseline@entry=0x0, 
    natural_baseline=0x0) at gtksizerequest.c:399
#15 0x00007ffff79b3a65 in gtk_widget_get_preferred_height_and_baseline_for_width (widget=widget@entry=0x555555e59170, width=width@entry=-1, 
    minimum_height=minimum_height@entry=0x7fffffffb540, natural_height=natural_height@entry=0x7fffffffb544, minimum_baseline=minimum_baseline@entry=0x0, 
    natural_baseline=natural_baseline@entry=0x0) at gtksizerequest.c:642
#16 0x00007ffff79b3bab in _gtk_widget_get_preferred_size_and_baseline (widget=0x555555e59170, minimum_size=minimum_size@entry=0x7fffffffb598, 
    natural_size=natural_size@entry=0x0, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=natural_baseline@entry=0x0) at gtksizerequest.c:703
#17 0x00007ffff79b3bfe in gtk_widget_get_preferred_size (widget=<optimized out>, minimum_size=minimum_size@entry=0x7fffffffb598, natural_size=natural_size@entry=0x0)
    at gtksizerequest.c:750
#18 0x00007ffff799d049 in gtk_scrolled_window_measure (gadget=<optimized out>, orientation=GTK_ORIENTATION_HORIZONTAL, for_size=<optimized out>, 
    minimum_size=0x7fffffffb738, natural_size=0x7fffffffb73c, minimum_baseline=<optimized out>, natural_baseline=0x0, data=0x0) at gtkscrolledwindow.c:1835
#19 0x00007ffff784ede7 in gtk_css_custom_gadget_get_preferred_size (gadget=<optimized out>, orientation=<optimized out>, for_size=<optimized out>, 
    minimum=<optimized out>, natural=<optimized out>, minimum_baseline=<optimized out>, natural_baseline=0x0) at gtkcsscustomgadget.c:124
#20 0x00007ffff7853179 in gtk_css_gadget_get_preferred_size (gadget=0x7fffdc013b70, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=0x7fffffffb738, natural=0x7fffffffb73c, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtkcssgadget.c:683
#21 0x00007ffff79992e7 in gtk_scrolled_window_get_preferred_width (widget=<optimized out>, minimum_size=<optimized out>, natural_size=<optimized out>)
    at gtkscrolledwindow.c:4092
#22 0x00007ffff79b2f01 in gtk_widget_query_size_for_orientation (widget=widget@entry=0x7fffdc0184e0, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
--Type <RET> for more, q to quit, c to continue without paging--
    for_size=for_size@entry=-1, minimum_size=minimum_size@entry=0x7fffffffba38, natural_size=natural_size@entry=0x7fffffffba3c, 
    minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtksizerequest.c:181
#23 0x00007ffff79b3730 in gtk_widget_compute_size_for_orientation (widget=widget@entry=0x7fffdc0184e0, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=minimum@entry=0x7fffffffba38, natural=natural@entry=0x7fffffffba3c, minimum_baseline=minimum_baseline@entry=0x0, 
    natural_baseline=0x0) at gtksizerequest.c:399
#24 0x00007ffff79b381e in gtk_widget_get_preferred_width (widget=widget@entry=0x7fffdc0184e0, minimum_width=minimum_width@entry=0x7fffffffba38, 
    natural_width=natural_width@entry=0x7fffffffba3c) at gtksizerequest.c:492
#25 0x00007ffff79b3e70 in _gtk_widget_get_preferred_size_for_size (widget=0x7fffdc0184e0, orientation=GTK_ORIENTATION_HORIZONTAL, size=-1, minimum=0x7fffffffba38, 
    natural=0x7fffffffba3c, minimum_baseline=0x0, natural_baseline=0x0) at gtksizerequest.c:871
#26 0x00007ffff784ede7 in gtk_css_custom_gadget_get_preferred_size (gadget=<optimized out>, orientation=<optimized out>, for_size=<optimized out>, 
    minimum=<optimized out>, natural=<optimized out>, minimum_baseline=<optimized out>, natural_baseline=0x0) at gtkcsscustomgadget.c:124
#27 0x00007ffff7853179 in gtk_css_gadget_get_preferred_size (gadget=0x7fffdc025ba0, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=0x7fffffffba38, natural=0x7fffffffba3c, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtkcssgadget.c:683
#28 0x00007ffff7a57637 in gtk_viewport_get_preferred_width (widget=<optimized out>, minimum_size=<optimized out>, natural_size=<optimized out>) at gtkviewport.c:1070
#29 0x00007ffff79b2f01 in gtk_widget_query_size_for_orientation (widget=widget@entry=0x555555ee8c10, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum_size=minimum_size@entry=0x7fffffffbba8, natural_size=natural_size@entry=0x7fffffffbbac, 
    minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtksizerequest.c:181
#30 0x00007ffff79b3730 in gtk_widget_compute_size_for_orientation (widget=widget@entry=0x555555ee8c10, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=minimum@entry=0x7fffffffbba8, natural=natural@entry=0x7fffffffbbac, minimum_baseline=minimum_baseline@entry=0x0, 
    natural_baseline=0x0) at gtksizerequest.c:399
#31 0x00007ffff79b381e in gtk_widget_get_preferred_width (widget=widget@entry=0x555555ee8c10, minimum_width=minimum_width@entry=0x7fffffffbba8, 
    natural_width=natural_width@entry=0x7fffffffbbac) at gtksizerequest.c:492
#32 0x00007ffff799d0fa in gtk_scrolled_window_measure (gadget=<optimized out>, orientation=GTK_ORIENTATION_HORIZONTAL, for_size=<optimized out>, 
    minimum_size=0x7fffffffbd58, natural_size=0x7fffffffbd5c, minimum_baseline=<optimized out>, natural_baseline=0x0, data=0x0) at gtkscrolledwindow.c:1850
#33 0x00007ffff784ede7 in gtk_css_custom_gadget_get_preferred_size (gadget=<optimized out>, orientation=<optimized out>, for_size=<optimized out>, 
    minimum=<optimized out>, natural=<optimized out>, minimum_baseline=<optimized out>, natural_baseline=0x0) at gtkcsscustomgadget.c:124
#34 0x00007ffff7853179 in gtk_css_gadget_get_preferred_size (gadget=0x55555595e060, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=0x7fffffffbd58, natural=0x7fffffffbd5c, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtkcssgadget.c:683
#35 0x00007ffff79992e7 in gtk_scrolled_window_get_preferred_width (widget=<optimized out>, minimum_size=<optimized out>, natural_size=<optimized out>)
    at gtkscrolledwindow.c:4092
#36 0x00007ffff79b2f01 in gtk_widget_query_size_for_orientation (widget=widget@entry=0x555555912780, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum_size=minimum_size@entry=0x7fffffffbf08, natural_size=natural_size@entry=0x7fffffffbf10, 
    minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtksizerequest.c:181
#37 0x00007ffff79b3730 in gtk_widget_compute_size_for_orientation (widget=widget@entry=0x555555912780, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=minimum@entry=0x7fffffffbf08, natural=natural@entry=0x7fffffffbf10, minimum_baseline=minimum_baseline@entry=0x0, 
    natural_baseline=0x0) at gtksizerequest.c:399
#38 0x00007ffff79b381e in gtk_widget_get_preferred_width (widget=0x555555912780, minimum_width=minimum_width@entry=0x7fffffffbf08, 
    natural_width=natural_width@entry=0x7fffffffbf10) at gtksizerequest.c:492
#39 0x00007ffff78d848b in compute_request_for_child (natural_baseline=0x7fffffffbf14, minimum_baseline=0x7fffffffbf0c, natural=0x7fffffffbf10, minimum=0x7fffffffbf08, 
    contextual=0, orientation=GTK_ORIENTATION_HORIZONTAL, child=<optimized out>, request=0x7fffffffbfa0) at gtkgrid.c:681
#40 gtk_grid_request_non_spanning (contextual=0, orientation=GTK_ORIENTATION_HORIZONTAL, request=0x7fffffffbfa0) at gtkgrid.c:723
--Type <RET> for more, q to quit, c to continue without paging--
#41 gtk_grid_request_run (request=request@entry=0x7fffffffbfa0, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, contextual=contextual@entry=0)
    at gtkgrid.c:1132
#42 0x00007ffff78d86d5 in gtk_grid_get_size (grid=<optimized out>, orientation=GTK_ORIENTATION_HORIZONTAL, minimum=0x7fffffffc158, natural=0x7fffffffc15c, 
    minimum_baseline=0x0, natural_baseline=<optimized out>) at gtkgrid.c:1438
#43 0x00007ffff784ede7 in gtk_css_custom_gadget_get_preferred_size (gadget=<optimized out>, orientation=<optimized out>, for_size=<optimized out>, 
    minimum=<optimized out>, natural=<optimized out>, minimum_baseline=<optimized out>, natural_baseline=0x0) at gtkcsscustomgadget.c:124
#44 0x00007ffff7853179 in gtk_css_gadget_get_preferred_size (gadget=0x555555871870, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=0x7fffffffc158, natural=0x7fffffffc15c, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtkcssgadget.c:683
#45 0x00007ffff78d6747 in gtk_grid_get_preferred_width (widget=<optimized out>, minimum=<optimized out>, natural=<optimized out>) at gtkgrid.c:1490
#46 0x00007ffff79b2f01 in gtk_widget_query_size_for_orientation (widget=widget@entry=0x555555926610, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum_size=minimum_size@entry=0x7fffffffc2e0, natural_size=natural_size@entry=0x7fffffffc2e4, 
    minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtksizerequest.c:181
#47 0x00007ffff79b3730 in gtk_widget_compute_size_for_orientation (widget=widget@entry=0x555555926610, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=minimum@entry=0x7fffffffc2e0, natural=natural@entry=0x7fffffffc2e4, minimum_baseline=minimum_baseline@entry=0x0, 
    natural_baseline=0x0) at gtksizerequest.c:399
#48 0x00007ffff79b381e in gtk_widget_get_preferred_width (widget=widget@entry=0x555555926610, minimum_width=minimum_width@entry=0x7fffffffc2e0, 
    natural_width=natural_width@entry=0x7fffffffc2e4) at gtksizerequest.c:492
#49 0x00007ffff79b9f0a in gtk_stack_measure (gadget=<optimized out>, orientation=GTK_ORIENTATION_HORIZONTAL, for_size=-1, minimum=0x7fffffffc478, 
    natural=0x7fffffffc47c, minimum_baseline=<optimized out>, natural_baseline=0x0, data=0x0) at gtkstack.c:2410
#50 0x00007ffff784ede7 in gtk_css_custom_gadget_get_preferred_size (gadget=<optimized out>, orientation=<optimized out>, for_size=<optimized out>, 
    minimum=<optimized out>, natural=<optimized out>, minimum_baseline=<optimized out>, natural_baseline=0x0) at gtkcsscustomgadget.c:124
#51 0x00007ffff7853179 in gtk_css_gadget_get_preferred_size (gadget=0x55555574c500, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=0x7fffffffc478, natural=0x7fffffffc47c, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtkcssgadget.c:683
#52 0x00007ffff79bac2b in gtk_stack_get_preferred_width (widget=<optimized out>, minimum=<optimized out>, natural=<optimized out>) at gtkstack.c:2311
#53 0x00007ffff79b2f01 in gtk_widget_query_size_for_orientation (widget=widget@entry=0x555555653450, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum_size=minimum_size@entry=0x7fffffffc64c, natural_size=natural_size@entry=0x7fffffffc650, 
    minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtksizerequest.c:181
#54 0x00007ffff79b3730 in gtk_widget_compute_size_for_orientation (widget=widget@entry=0x555555653450, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=minimum@entry=0x7fffffffc64c, natural=natural@entry=0x7fffffffc650, minimum_baseline=minimum_baseline@entry=0x0, 
    natural_baseline=0x0) at gtksizerequest.c:399
#55 0x00007ffff79b381e in gtk_widget_get_preferred_width (widget=widget@entry=0x555555653450, minimum_width=minimum_width@entry=0x7fffffffc64c, 
    natural_width=natural_width@entry=0x7fffffffc650) at gtksizerequest.c:492
#56 0x00007ffff79b3e70 in _gtk_widget_get_preferred_size_for_size (widget=0x555555653450, orientation=GTK_ORIENTATION_HORIZONTAL, size=size@entry=-1, 
    minimum=minimum@entry=0x7fffffffc64c, natural=natural@entry=0x7fffffffc650, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0)
    at gtksizerequest.c:871
#57 0x00007ffff794c1c2 in gtk_paned_get_preferred_size_for_orientation (natural=0x7fffffffc7ec, minimum=0x7fffffffc7e8, size=-1, widget=<optimized out>)
    at gtkpaned.c:1076
#58 gtk_paned_measure (gadget=<optimized out>, orientation=GTK_ORIENTATION_HORIZONTAL, size=-1, minimum=0x7fffffffc7e8, natural=0x7fffffffc7ec, 
    minimum_baseline=<optimized out>, natural_baseline=0x0, data=0x0) at gtkpaned.c:1237
#59 0x00007ffff784ede7 in gtk_css_custom_gadget_get_preferred_size (gadget=<optimized out>, orientation=<optimized out>, for_size=<optimized out>, 
    minimum=<optimized out>, natural=<optimized out>, minimum_baseline=<optimized out>, natural_baseline=0x0) at gtkcsscustomgadget.c:124
--Type <RET> for more, q to quit, c to continue without paging--
#60 0x00007ffff7853179 in gtk_css_gadget_get_preferred_size (gadget=0x55555574c280, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=0x7fffffffc7e8, natural=0x7fffffffc7ec, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtkcssgadget.c:683
#61 0x00007ffff794b687 in gtk_paned_get_preferred_width (widget=<optimized out>, minimum=<optimized out>, natural=<optimized out>) at gtkpaned.c:1247
#62 0x00007ffff79b2f01 in gtk_widget_query_size_for_orientation (widget=widget@entry=0x55555565c620, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum_size=minimum_size@entry=0x7fffffffc968, natural_size=natural_size@entry=0x7fffffffc96c, 
    minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtksizerequest.c:181
#63 0x00007ffff79b3730 in gtk_widget_compute_size_for_orientation (widget=widget@entry=0x55555565c620, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=minimum@entry=0x7fffffffc968, natural=natural@entry=0x7fffffffc96c, minimum_baseline=minimum_baseline@entry=0x0, 
    natural_baseline=0x0) at gtksizerequest.c:399
#64 0x00007ffff79b381e in gtk_widget_get_preferred_width (widget=widget@entry=0x55555565c620, minimum_width=minimum_width@entry=0x7fffffffc968, 
    natural_width=natural_width@entry=0x7fffffffc96c) at gtksizerequest.c:492
#65 0x00007ffff7a74192 in gtk_window_get_preferred_width (widget=0x5555559062e0, minimum_size=0x7fffffffca78, natural_size=0x7fffffffca7c) at gtkwindow.c:8782
#66 0x00007ffff77efa64 in gtk_application_window_real_get_preferred_width (widget=0x5555559062e0, minimum_width=0x7fffffffca78, natural_width=0x7fffffffca7c)
    at gtkapplicationwindow.c:576
#67 0x00007ffff79b2f01 in gtk_widget_query_size_for_orientation (widget=widget@entry=0x5555559062e0, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum_size=minimum_size@entry=0x7fffffffcbe0, natural_size=natural_size@entry=0x7fffffffcbe4, 
    minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=0x0) at gtksizerequest.c:181
#68 0x00007ffff79b3730 in gtk_widget_compute_size_for_orientation (widget=widget@entry=0x5555559062e0, orientation=orientation@entry=GTK_ORIENTATION_HORIZONTAL, 
    for_size=for_size@entry=-1, minimum=minimum@entry=0x7fffffffcbe0, natural=natural@entry=0x7fffffffcbe4, minimum_baseline=minimum_baseline@entry=0x0, 
    natural_baseline=0x0) at gtksizerequest.c:399
#69 0x00007ffff79b381e in gtk_widget_get_preferred_width (widget=widget@entry=0x5555559062e0, minimum_width=minimum_width@entry=0x7fffffffcbe0, 
    natural_width=natural_width@entry=0x7fffffffcbe4) at gtksizerequest.c:492
#70 0x00007ffff79b3b4c in _gtk_widget_get_preferred_size_and_baseline (widget=widget@entry=0x5555559062e0, minimum_size=minimum_size@entry=0x7fffffffcc80, 
    natural_size=natural_size@entry=0x0, minimum_baseline=minimum_baseline@entry=0x0, natural_baseline=natural_baseline@entry=0x0) at gtksizerequest.c:685
#71 0x00007ffff79b3bfe in gtk_widget_get_preferred_size (widget=widget@entry=0x5555559062e0, minimum_size=minimum_size@entry=0x7fffffffcc80, 
    natural_size=natural_size@entry=0x0) at gtksizerequest.c:750
#72 0x00007ffff7a75714 in gtk_window_compute_hints (new_flags=<synthetic pointer>, new_geometry=0x7fffffffcc90, window=0x5555559062e0) at gtkwindow.c:10234
#73 gtk_window_compute_configure_request (window=window@entry=0x5555559062e0, request=request@entry=0x7fffffffcd80, geometry=geometry@entry=0x7fffffffcda0, 
    flags=flags@entry=0x7fffffffcd78) at gtkwindow.c:9550
#74 0x00007ffff7a7611c in gtk_window_move_resize (window=0x5555559062e0) at gtkwindow.c:9759
#75 gtk_window_check_resize (container=0x5555559062e0) at gtkwindow.c:8516
#76 0x00007ffff73c10b6 in _g_closure_invoke_va (closure=0x5555556748b0, return_value=0x0, instance=0x5555559062e0, args=0x7fffffffd040, n_params=0, param_types=0x0)
    at ../gobject/gclosure.c:873
#77 0x00007ffff73de330 in g_signal_emit_valist (instance=0x5555559062e0, signal_id=<optimized out>, detail=<optimized out>, var_args=var_args@entry=0x7fffffffd040)
    at ../gobject/gsignal.c:3300
#78 0x00007ffff73de933 in g_signal_emit (instance=<optimized out>, signal_id=<optimized out>, detail=<optimized out>) at ../gobject/gsignal.c:3447
#79 0x00007ffff7848058 in gtk_container_idle_sizer (clock=0x55555568e2d0, container=0x5555559062e0) at gtkcontainer.c:2064
#80 0x00007ffff73c0e5d in g_closure_invoke (closure=0x7fffdc02cd20, return_value=0x0, n_param_values=1, param_values=0x7fffffffd300, invocation_hint=0x7fffffffd280)
    at ../gobject/gclosure.c:810
#81 0x00007ffff73d4f23 in signal_emit_unlocked_R (node=node@entry=0x5555556691e0, detail=detail@entry=0, instance=instance@entry=0x55555568e2d0, 
    emission_return=emission_return@entry=0x0, instance_and_params=instance_and_params@entry=0x7fffffffd300) at ../gobject/gsignal.c:3635
--Type <RET> for more, q to quit, c to continue without paging--
#82 0x00007ffff73de2da in g_signal_emit_valist (instance=<optimized out>, signal_id=<optimized out>, detail=<optimized out>, var_args=var_args@entry=0x7fffffffd4b0)
    at ../gobject/gsignal.c:3391
#83 0x00007ffff73de933 in g_signal_emit (instance=instance@entry=0x55555568e2d0, signal_id=<optimized out>, detail=detail@entry=0) at ../gobject/gsignal.c:3447
#84 0x00007ffff7611e73 in _gdk_frame_clock_emit_layout (frame_clock=frame_clock@entry=0x55555568e2d0) at gdkframeclock.c:634
#85 0x00007ffff761256a in gdk_frame_clock_paint_idle (data=0x55555568e2d0) at gdkframeclockidle.c:437
#86 0x00007ffff75fcc8c in gdk_threads_dispatch (data=0x555555802000, data@entry=<error reading variable: value has been optimized out>) at gdk.c:768
#87 0x00007ffff72de007 in g_timeout_dispatch (source=0x7fffdc02cda0, callback=<optimized out>, user_data=<optimized out>) at ../glib/gmain.c:4667
#88 0x00007ffff72dd528 in g_main_dispatch (context=0x5555555e19b0) at ../glib/gmain.c:3182
#89 g_main_context_dispatch (context=context@entry=0x5555555e19b0) at ../glib/gmain.c:3847
#90 0x00007ffff72dd918 in g_main_context_iterate (context=context@entry=0x5555555e19b0, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>)
    at ../glib/gmain.c:3920
#91 0x00007ffff72dd9b0 in g_main_context_iteration (context=context@entry=0x5555555e19b0, may_block=may_block@entry=1) at ../glib/gmain.c:3981
#92 0x00007ffff74da6b5 in g_application_run (application=0x5555555db0e0, argc=<optimized out>, argv=0x7fffffffd8c8) at ../gio/gapplication.c:2470
#93 0x000055555556104d in _vala_main (args=0x7fffffffd8c8, args_length1=1) at /home/alberto/projects/vala/sequeler/src/Main.vala:31
#94 0x0000555555561090 in main (argc=1, argv=0x7fffffffd8c8) at /home/alberto/projects/vala/sequeler/src/Main.vala:25
```
</details>

which seems related to css?