### PR TITLE
Fixes build faillure due to missing libfixposix dependency

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -57,13 +57,12 @@ executable(
         dependency('gobject-2.0'),
         dependency('libxml-2.0'),
         dependency('libgda-5.0'),
-        dependency('libfixposix'),
         dependency('libssh2'),
         dependency('libsecret-1'),
         dependency('gtksourceview-3.0'),
         m_dep,
         linux_dep
     ],
-		vala_args: vala_args,
+        vala_args: vala_args + ['--pkg', 'libfixposix'],
     install: true
 )


### PR DESCRIPTION
Attempting to build master on Fedora 29 yields

```
The Meson build system
Version: 0.49.0
Source dir: /home/jerry/Desktop/sequeler
Build dir: /home/jerry/Desktop/sequeler/build
Build type: native build
Project name: com.github.alecaddd.sequeler
Project version: 0.6.6
Native C compiler: cc (gcc 8.2.1 "cc (GCC) 8.2.1 20181215 (Red Hat 8.2.1-6)")
Native Vala compiler: valac (valac 0.42.3)
Build machine cpu family: x86_64
Build machine cpu: x86_64
Library m found: YES
Library linux found: YES
Found pkg-config: /usr/bin/pkg-config (1.5.3)
Program io.elementary.vala-lint found: NO
Configuring config.vala using configuration
Dependency gtk+-3.0 found: YES 3.24.1
Dependency granite found: YES 5.1.0
Dependency glib-2.0 found: YES 2.58.1
Dependency gee-0.8 found: YES 0.20.1
Dependency gobject-2.0 found: YES 2.58.1
Dependency libxml-2.0 found: YES 2.9.8
Dependency libgda-5.0 found: YES 5.2.8
Found CMake: NO
Dependency libfixposix found: NO (tried pkgconfig)

src/meson.build:14:0: ERROR:  Dependency "libfixposix" not found, tried pkgconfig
```
This change allows the build to proceed successfully.


By the way, there doesn't appear to be any actual difference between libfixposix.vapi and the posix.vapi shipped with vala? If that is the case, are you planning on making changes to it?

Just trying to understand the point of shipping it.

At this point it seems cleaner to just remove libfixposix.vapi and use ['--pkg', 'posix'] to get the same result.