### PR TITLE
Patch null values

### DIFF
--- a/src/Layouts/DataBaseSchema.vala
+++ b/src/Layouts/DataBaseSchema.vala
@@ -448,6 +448,7 @@ public class Sequeler.Layouts.DataBaseSchema : Gtk.Grid {
 						window.main.connection_manager.query_warning (error);
 						return false;
 					}
+					reload_schema.begin ();
 					return false;
 				});
 

--- a/src/Layouts/DataBaseSchema.vala
+++ b/src/Layouts/DataBaseSchema.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (http://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Layouts/Views/Content.vala
+++ b/src/Layouts/Views/Content.vala
@@ -249,30 +249,13 @@ public class Sequeler.Layouts.Views.Content : Gtk.Grid {
 	}
 
 	private async Gda.DataModel? get_table_content (string query) {
-		SourceFunc callback = get_table_content.callback;
 		Gda.DataModel? result = null;
-		var error = "";
 
-		window.main.connection_manager.init_select_query.begin (query, (obj, res) => {
-			ThreadFunc<bool> run = () => {
-				try {
-					result = window.main.connection_manager.init_select_query.end (res);
-				} catch (ThreadError e) {
-					error = e.message;
-					result = null;
-				}
-				Idle.add((owned) callback);
-				return true;
-			};
-			new Thread<bool> ("get-table-content", run);
-		});
+		result = yield window.main.connection_manager.init_select_query (query);
 
-		yield;
-
-		if (error != "") {
-			window.main.connection_manager.query_warning (error);
-			result_message.label = error;
-			return null;
+		if (result == null) {
+			reloading = false;
+			yield reset ();
 		}
 
 		return result;

--- a/src/Layouts/Views/Content.vala
+++ b/src/Layouts/Views/Content.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (http://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Layouts/Views/Query.vala
+++ b/src/Layouts/Views/Query.vala
@@ -285,30 +285,16 @@ public class Sequeler.Layouts.Views.Query : Gtk.Grid {
 		var explain_pos = query.down ().index_of ("explain", 0);
 
 		if (select_pos == 0 || show_pos == 0 || pragma_pos == 0 || explain_pos == 0) {
-			handle_select_response (select_statement (query));
+			select_statement.begin (query, (obj, res) => {
+				handle_select_response (select_statement.end (res));
+			});
 		} else {
 			handle_query_response (non_select_statement (query));
 		}
 	}
 
-	public Gda.DataModel? select_statement (string query) {
-		Gda.DataModel? result = null;
-		var error = "";
-
-		var loop = new MainLoop ();
-		window.main.connection_manager.init_select_query.begin (query, (obj, res) => {
-			try {
-				result = window.main.connection_manager.init_select_query.end (res);
-			} catch (ThreadError e) {
-				error = e.message;
-				result = null;
-			}
-			loop.quit ();
-		});
-
-		loop.run ();
-
-		return result;
+	private async Gda.DataModel? select_statement (string query) {
+		return yield window.main.connection_manager.init_select_query (query);
 	}
 
 	public int? non_select_statement (string query) {

--- a/src/Layouts/Views/Query.vala
+++ b/src/Layouts/Views/Query.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (http://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Layouts/Views/Relations.vala
+++ b/src/Layouts/Views/Relations.vala
@@ -196,30 +196,13 @@ public class Sequeler.Layouts.Views.Relations : Gtk.Grid {
 	}
 
 	private async Gda.DataModel? get_table_relations (string query) {
-		SourceFunc callback = get_table_relations.callback;
 		Gda.DataModel? result = null;
-		var error = "";
 
-		window.main.connection_manager.init_select_query.begin (query, (obj, res) => {
-			ThreadFunc<bool> run = () => {
-				try {
-					result = window.main.connection_manager.init_select_query.end (res);
-				} catch (ThreadError e) {
-					error = e.message;
-					result = null;
-				}
-				Idle.add((owned) callback);
-				return true;
-			};
-			new Thread<bool> ("get-table-relations", run);
-		});
+		result = yield window.main.connection_manager.init_select_query (query);
 
-		yield;
-
-		if (error != "") {
-			window.main.connection_manager.query_warning (error);
-			result_message.label = error;
-			return null;
+		if (result == null) {
+			reloading = false;
+			yield reset ();
 		}
 
 		return result;

--- a/src/Layouts/Views/Relations.vala
+++ b/src/Layouts/Views/Relations.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (http://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Layouts/Views/Structure.vala
+++ b/src/Layouts/Views/Structure.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (http://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Layouts/Views/Structure.vala
+++ b/src/Layouts/Views/Structure.vala
@@ -197,30 +197,13 @@ public class Sequeler.Layouts.Views.Structure : Gtk.Grid {
 	}
 
 	private async Gda.DataModel? get_table_schema (string query) {
-		SourceFunc callback = get_table_schema.callback;
 		Gda.DataModel? result = null;
-		var error = "";
 
-		window.main.connection_manager.init_select_query.begin (query, (obj, res) => {
-			ThreadFunc<bool> run = () => {
-				try {
-					result = window.main.connection_manager.init_select_query.end (res);
-				} catch (ThreadError e) {
-					error = e.message;
-					result = null;
-				}
-				Idle.add((owned) callback);
-				return true;
-			};
-			new Thread<bool> ("get-table-schema", run);
-		});
+		result = yield window.main.connection_manager.init_select_query (query);
 
-		yield;
-
-		if (error != "") {
-			window.main.connection_manager.query_warning (error);
-			result_message.label = error;
-			return null;
+		if (result == null) {
+			reloading = false;
+			yield reset ();
 		}
 
 		return result;

--- a/src/Partials/TreeBuilder.vala
+++ b/src/Partials/TreeBuilder.vala
@@ -107,8 +107,7 @@ public class Sequeler.Partials.TreeBuilder : Gtk.TreeView {
 			var placeholder_type = data.describe_column (i).get_g_type ();
 
 			try {
-				var sanitized_value = sanitize_value (_iter.get_value_at_e (i));
-				if (sanitized_value == "") {
+				if (_iter.get_value_at_e (i).strdup_contents  () == "NULL") {
 					store.set_value (iter, i, GLib.Value (placeholder_type));
 				} else {
 					store.set_value (iter, i, _iter.get_value_at_e (i));
@@ -129,21 +128,6 @@ public class Sequeler.Partials.TreeBuilder : Gtk.TreeView {
 			store.set_value (iter, tot_columns, background);
 			i++;
 		}
-	}
-
-	private string? sanitize_value (Value raw_value) {
-		Gda.DataHandler handler = Gda.DataHandler.get_default (raw_value.type ());
-		if (! (handler is Gda.DataHandler)) {
-			return "";
-		}
-
-		string? column_data = handler.get_str_from_value (raw_value);
-
-		if (column_data == null) {
-			column_data = "";
-		}
-
-		return column_data;
 	}
 
 	private void copy_column_data (Gdk.EventButton event, Gtk.TreePath path, Gtk.TreeViewColumn column) {

--- a/src/Partials/TreeBuilder.vala
+++ b/src/Partials/TreeBuilder.vala
@@ -108,7 +108,7 @@ public class Sequeler.Partials.TreeBuilder : Gtk.TreeView {
 
 			try {
 				var raw_value = _iter.get_value_at_e (i);
-				var sanitized_value = raw_value.strdup_contents  () != "NULL" ?
+				var sanitized_value = raw_value.strdup_contents () != "NULL" ?
 									  raw_value : GLib.Value (placeholder_type);
 
 				store.set_value (iter, i, sanitized_value);

--- a/src/Partials/TreeBuilder.vala
+++ b/src/Partials/TreeBuilder.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (http://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Partials/TreeBuilder.vala
+++ b/src/Partials/TreeBuilder.vala
@@ -107,11 +107,11 @@ public class Sequeler.Partials.TreeBuilder : Gtk.TreeView {
 			var placeholder_type = data.describe_column (i).get_g_type ();
 
 			try {
-				if (_iter.get_value_at_e (i).strdup_contents  () == "NULL") {
-					store.set_value (iter, i, GLib.Value (placeholder_type));
-				} else {
-					store.set_value (iter, i, _iter.get_value_at_e (i));
-				}
+				var raw_value = _iter.get_value_at_e (i);
+				var sanitized_value = raw_value.strdup_contents  () != "NULL" ?
+									  raw_value : GLib.Value (placeholder_type);
+
+				store.set_value (iter, i, sanitized_value);
 			} catch (Error e) {
 				error_message = "%s %s %s %s: %s".printf (_("Error"), e.code.to_string (), _("on Column"), data.get_column_title (i), e.message.to_string ());
 			}

--- a/src/Services/ConnectionManager.vala
+++ b/src/Services/ConnectionManager.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (http://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Services/ConnectionManager.vala
+++ b/src/Services/ConnectionManager.vala
@@ -454,7 +454,7 @@ public class Sequeler.Services.ConnectionManager : Object {
 		return output;
 	}
 
-	public async Gda.DataModel? init_select_query (string query) throws ThreadError {
+	public async Gda.DataModel? init_select_query (string query) {
 		Gda.DataModel? result = null;
 		SourceFunc callback = init_select_query.callback;
 		var error = "";

--- a/src/Services/Types/MySQL.vala
+++ b/src/Services/Types/MySQL.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (https://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Services/Types/PostgreSQL.vala
+++ b/src/Services/Types/PostgreSQL.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (https://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Services/Types/SQLite.vala
+++ b/src/Services/Types/SQLite.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2011-2018 Alecaddd (http://alecaddd.com)
+* Copyright (c) 2011-2019 Alecaddd (https://alecaddd.com)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public


### PR DESCRIPTION
This PR takes care of removing `GTK WARNINGS` when  trying to print `GdaNull` values in column cells with a different `GLib.Type`.
Also, improves the code regarding select query async methods.

Fixes #213