### PR TITLE
Add snapcraft yaml

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -1,0 +1,111 @@
+name: sequeler
+base: core18 
+version: master
+summary: Sequeler
+description: |
+  SQL Client built in Vala
+
+grade: stable
+confinement: strict
+
+apps:
+  sequeler:
+    extensions: [gnome-3-28]
+    command: usr/bin/com.github.alecaddd.sequeler
+    plugs:
+      - desktop
+      - desktop-legacy
+      - opengl
+      - x11
+    slots: [ dbus-sequeler ]
+    desktop: usr/share/applications/com.github.alecaddd.sequeler.desktop
+    environment:
+      GSETTINGS_SCHEMA_DIR: $SNAP/share/glib-2.0/schemas
+      GTK_USE_PORTAL: "1"
+
+slots:
+  dbus-sequeler:
+    interface: dbus
+    bus: session
+    name: com.github.alecaddd.sequeler
+
+parts:
+  elementary-sdk:
+    plugin: nil
+    build-packages:
+      - software-properties-common
+    override-pull: |
+      add-apt-repository -y ppa:elementary-os/stable
+      add-apt-repository -y ppa:elementary-os/os-patches
+      apt -y update
+      apt -y upgrade
+  sequeler:
+    plugin: meson
+    after: [elementary-sdk]
+    meson-parameters:
+      - --prefix=/usr
+    source: .
+    override-build: |
+      snapcraftctl build
+      sed -i 's|Icon=com.github.alecaddd.sequeler|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/com.github.alecaddd.sequeler.svg|' ${SNAPCRAFT_PART_INSTALL}/usr/share/applications/com.github.alecaddd.sequeler.desktop
+    build-packages:
+      - libgtk-3-dev
+      - libgda-5.0-dev
+      - libssh2-1-dev
+      - libsecret-1-dev
+      - valac
+      - libgranite-dev
+      - libjson-glib-dev
+      - libgudev-1.0-dev
+      - libevdev-dev
+      - libgtksourceview-3.0-dev
+      - libmysqlclient-dev
+      - libgda-5.0-mysql
+      - libpq-dev
+      - libsqlite3-dev
+      - libgda-5.0-postgres
+      - libxml2-dev
+      - libglib2.0-dev
+      - libgoocanvas-2.0-dev
+      - libarchive-dev
+    stage-packages:
+      - libdatrie1
+      - libdbus-1-3
+      - libepoxy0
+      - libexpat1
+      - libffi6
+      - libgcrypt20
+      - libgee-0.8-2
+      - libgda-5.0-4
+      - libgpg-error0
+      - libgraphite2-3
+      - libharfbuzz0b
+      - libarchive13
+      - libgoocanvas-2.0-9
+      - libgranite5
+      - liblz4-1
+      - liblzma5
+      - libmount1
+      - libpcre3
+      - libpixman-1-0
+      - libpng16-16
+      - libthai0
+      - libwayland-client0
+      - libwayland-cursor0
+      - libwayland-egl1-mesa
+      - libx11-6
+      - libxau6
+      - libxcb1
+      - libxcb-render0
+      - libxcb-shm0
+      - libxcomposite1
+      - libxcursor1
+      - libxdamage1
+      - libxdmcp6
+      - libxext6
+      - libxfixes3
+      - libxi6
+      - libxinerama1
+      - libxkbcommon0
+      - libxrender1
+      - zlib1g


### PR DESCRIPTION
This adds the ability to build a snap of sequeler. It's unsurprisingly based off the yaml for akira :).

I haven't fully tested it as I don't have many databases kicking around here. I tried connecting to a SQL  lite database but it said "No provider 'SQLite' installed". What's missing?

![Screenshot from 2020-04-01 21-41-16](https://user-images.githubusercontent.com/1841272/78184561-980f2300-7461-11ea-9d9f-bcf296497097.png)
