### PR TITLE
Support unencrypted connections

### DIFF
--- a/src/Services/Types/MySQL.vala
+++ b/src/Services/Types/MySQL.vala
@@ -26,7 +26,7 @@ public class Sequeler.Services.Types.MySQL : Object, DataBaseType {
     public string connection_string (Gee.HashMap<string, string> data) {
         var username = Gda.rfc1738_encode (data["username"]);
         var password = Gda.rfc1738_encode (data["password"]);
-        var use_ssl = Gda.rfc1738_encode (data["use_ssl"] ?? "true");
+        var use_ssl = Gda.rfc1738_encode (data["use_ssl"] ?? "false");
         var name = Gda.rfc1738_encode (data["name"]);
         if (data["has_ssh"] == "true") {
             port = "9000";

--- a/src/Services/Types/MySQL.vala
+++ b/src/Services/Types/MySQL.vala
@@ -26,6 +26,7 @@ public class Sequeler.Services.Types.MySQL : Object, DataBaseType {
     public string connection_string (Gee.HashMap<string, string> data) {
         var username = Gda.rfc1738_encode (data["username"]);
         var password = Gda.rfc1738_encode (data["password"]);
+        var use_ssl = Gda.rfc1738_encode (data["use_ssl"] ?? "true");
         var name = Gda.rfc1738_encode (data["name"]);
         if (data["has_ssh"] == "true") {
             port = "9000";
@@ -35,7 +36,7 @@ public class Sequeler.Services.Types.MySQL : Object, DataBaseType {
             host = data["host"] != "" ? Gda.rfc1738_encode (data["host"]) : host;
         }
 
-        return "MySQL://" + username + ":" + password + "@DB_NAME=" + name + ";HOST=" + host + ";PORT=" + port;
+        return "MySQL://" + username + ":" + password + "@DB_NAME=" + name + ";HOST=" + host + ";PORT=" + port + ";USE_SSL=" + use_ssl;
     }
 
     public string show_schema () {

--- a/src/Services/Types/PostgreSQL.vala
+++ b/src/Services/Types/PostgreSQL.vala
@@ -26,6 +26,7 @@ public class Sequeler.Services.Types.PostgreSQL : Object, DataBaseType {
     public string connection_string (Gee.HashMap<string, string> data) {
         var username = Gda.rfc1738_encode (data["username"]);
         var password = Gda.rfc1738_encode (data["password"]);
+        var use_ssl = Gda.rfc1738_encode (data["use_ssl"] ?? "true");
         var name = Gda.rfc1738_encode (data["name"]);
         host = data["host"] != "" ? Gda.rfc1738_encode (data["host"]) : host;
         if (data["has_ssh"] == "true") {
@@ -34,7 +35,7 @@ public class Sequeler.Services.Types.PostgreSQL : Object, DataBaseType {
             port = data["port"] != "" ? data["port"] : port;
         }
 
-        return "PostgreSQL://" + username + ":" + password + "@DB_NAME=" + name + ";HOST=" + host + ";PORT=" + port;
+        return "PostgreSQL://" + username + ":" + password + "@DB_NAME=" + name + ";HOST=" + host + ";PORT=" + port + ";USE_SSL=" + use_ssl;
     }
 
     public string show_schema () {

--- a/src/Services/Types/PostgreSQL.vala
+++ b/src/Services/Types/PostgreSQL.vala
@@ -26,7 +26,7 @@ public class Sequeler.Services.Types.PostgreSQL : Object, DataBaseType {
     public string connection_string (Gee.HashMap<string, string> data) {
         var username = Gda.rfc1738_encode (data["username"]);
         var password = Gda.rfc1738_encode (data["password"]);
-        var use_ssl = Gda.rfc1738_encode (data["use_ssl"] ?? "true");
+        var use_ssl = Gda.rfc1738_encode (data["use_ssl"] ?? "false");
         var name = Gda.rfc1738_encode (data["name"]);
         host = data["host"] != "" ? Gda.rfc1738_encode (data["host"]) : host;
         if (data["has_ssh"] == "true") {

--- a/src/Widgets/ConnectionDialog.vala
+++ b/src/Widgets/ConnectionDialog.vala
@@ -243,7 +243,7 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 
         ssl_switch_label = new Sequeler.Partials.LabelForm (_("Use SSL:"));
         ssl_switch = new Gtk.Switch ();
-        ssl_switch.set_state (true);
+        ssl_switch.set_state (false);
 
         form_grid.attach (ssl_switch_label, 0, 7, 1, 1);
         form_grid.attach (ssl_switch, 1, 7, 1, 1);

--- a/src/Widgets/ConnectionDialog.vala
+++ b/src/Widgets/ConnectionDialog.vala
@@ -55,6 +55,8 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 
     private string keyfile1;
     private string keyfile2;
+    private Sequeler.Partials.LabelForm ssl_switch_label;
+    private Gtk.Switch ssl_switch;
     private Sequeler.Partials.LabelForm ssh_switch_label;
     private Gtk.Grid ssh_switch_container;
     private Gtk.Switch ssh_switch;
@@ -238,6 +240,13 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 
         form_grid.attach (db_port_label, 0, 6, 1, 1);
         form_grid.attach (db_port_entry, 1, 6, 1, 1);
+
+        ssl_switch_label = new Sequeler.Partials.LabelForm (_("Use SSL:"));
+        ssl_switch = new Gtk.Switch ();
+        ssl_switch.set_state (true);
+
+        form_grid.attach (ssl_switch_label, 0, 7, 1, 1);
+        form_grid.attach (ssl_switch, 1, 7, 1, 1);
 
         db_file_label = new Sequeler.Partials.LabelForm (_("File Path:"));
         db_file_entry = new Gtk.FileChooserButton (_("Select Your SQLite File\u2026"), Gtk.FileChooserAction.OPEN);
@@ -505,6 +514,10 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
                 ssh_identity_file_entry.set_filename (update_data["ssh_identity_file"]);
             }
         }
+
+        if (update_data["use_ssl"] != null) {
+            ssl_switch.set_state (update_data["use_ssl"] == "true");
+        }
     }
 
     private void db_type_changed () {
@@ -545,6 +558,10 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
         db_port_label.no_show_all = toggle;
         db_port_entry.visible = !toggle;
         db_port_entry.no_show_all = toggle;
+        ssl_switch_label.visible = !toggle;
+        ssl_switch_label.no_show_all = toggle;
+        ssl_switch.visible = !toggle;
+        ssl_switch.no_show_all = toggle;
 
         if (toggle) ssh_switch.active = false;
 
@@ -756,6 +773,8 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
         packaged_data.set ("ssh_password", ssh_switch.active ? ssh_password_entry.text : "");
         packaged_data.set ("ssh_port", ssh_switch.active ? ssh_port_entry.text : "");
         packaged_data.set ("ssh_identity_file", ssh_identity_file_entry.get_filename () ?? "");
+
+        packaged_data.set ("use_ssl", ssl_switch.active.to_string ());
 
         return packaged_data;
     }

--- a/src/Widgets/ConnectionDialog.vala
+++ b/src/Widgets/ConnectionDialog.vala
@@ -56,6 +56,7 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
     private string keyfile1;
     private string keyfile2;
     private Sequeler.Partials.LabelForm ssl_switch_label;
+    private Gtk.Grid ssl_switch_container;
     private Gtk.Switch ssl_switch;
     private Sequeler.Partials.LabelForm ssh_switch_label;
     private Gtk.Grid ssh_switch_container;
@@ -243,10 +244,12 @@ public class Sequeler.Widgets.ConnectionDialog : Gtk.Dialog {
 
         ssl_switch_label = new Sequeler.Partials.LabelForm (_("Use SSL:"));
         ssl_switch = new Gtk.Switch ();
+        ssl_switch_container = new Gtk.Grid ();
+        ssl_switch_container.add (ssl_switch);
         ssl_switch.set_state (false);
 
         form_grid.attach (ssl_switch_label, 0, 7, 1, 1);
-        form_grid.attach (ssl_switch, 1, 7, 1, 1);
+        form_grid.attach (ssl_switch_container, 1, 7, 1, 1);
 
         db_file_label = new Sequeler.Partials.LabelForm (_("File Path:"));
         db_file_entry = new Gtk.FileChooserButton (_("Select Your SQLite File\u2026"), Gtk.FileChooserAction.OPEN);


### PR DESCRIPTION
`libgda` supports a `USE_SSL` param for both MySQL and Postgres connections, which is currently not surfaced in `sequeler`.

This adds a switch for SSL to the connection dialog, and appends it to the connection string for these databases. It defaults to on for the upgrade case where it is unset (TODO: whether this is the correct behaviour).

The motivating case is working with databases on both internal and external networks where control over this is useful.

I haven't worked with Vala before. This might require some iterations.