### PR TITLE
Explicitly start and stop gtk spinners

### DIFF
--- a/src/Layouts/DataBaseSchema.vala
+++ b/src/Layouts/DataBaseSchema.vala
@@ -131,7 +131,6 @@ public class Sequeler.Layouts.DataBaseSchema : Gtk.Grid {
         spinner.vexpand = true;
         spinner.halign = Gtk.Align.CENTER;
         spinner.valign = Gtk.Align.CENTER;
-        spinner.start ();
 
         toolbar.attach (add_table_btn, 0, 0, 1, 1);
         toolbar.attach (new Gtk.Separator (Gtk.Orientation.VERTICAL), 1, 0, 1, 1);
@@ -147,15 +146,15 @@ public class Sequeler.Layouts.DataBaseSchema : Gtk.Grid {
         attach (revealer, 0, 1, 1, 1);
         attach (stack, 0, 2, 1, 2);
         attach (toolbar, 0, 4, 1, 1);
-
-        start_spinner ();
     }
 
     public void start_spinner () {
+        spinner.start ();
         stack.visible_child_name = "spinner";
     }
 
     public void stop_spinner () {
+        spinner.stop ();
         stack.visible_child_name = "list";
     }
 

--- a/src/Layouts/Views/Content.vala
+++ b/src/Layouts/Views/Content.vala
@@ -85,7 +85,6 @@ public class Sequeler.Layouts.Views.Content : Gtk.Grid {
         spinner.vexpand = true;
         spinner.halign = Gtk.Align.CENTER;
         spinner.valign = Gtk.Align.CENTER;
-        spinner.start ();
 
         var welcome = new Granite.Widgets.Welcome (_("Select Table"), _("Select a table from the left sidebar to activate this view."));
 
@@ -107,10 +106,12 @@ public class Sequeler.Layouts.Views.Content : Gtk.Grid {
     }
 
     public void start_spinner () {
+        spinner.start ();
         stack.visible_child_name = "spinner";
     }
 
     public void stop_spinner () {
+        spinner.stop ();
         stack.visible_child_name = "list";
     }
 

--- a/src/Layouts/Views/Relations.vala
+++ b/src/Layouts/Views/Relations.vala
@@ -73,7 +73,6 @@ public class Sequeler.Layouts.Views.Relations : Gtk.Grid {
         spinner.vexpand = true;
         spinner.halign = Gtk.Align.CENTER;
         spinner.valign = Gtk.Align.CENTER;
-        spinner.start ();
 
         var welcome = new Granite.Widgets.Welcome (_("Select Table"), _("Select a table from the left sidebar to activate this view."));
 
@@ -95,10 +94,12 @@ public class Sequeler.Layouts.Views.Relations : Gtk.Grid {
     }
 
     public void start_spinner () {
+        spinner.start ();
         stack.visible_child_name = "spinner";
     }
 
     public void stop_spinner () {
+        spinner.stop ();
         stack.visible_child_name = "list";
     }
 

--- a/src/Layouts/Views/Structure.vala
+++ b/src/Layouts/Views/Structure.vala
@@ -74,7 +74,6 @@ public class Sequeler.Layouts.Views.Structure : Gtk.Grid {
         spinner.vexpand = true;
         spinner.halign = Gtk.Align.CENTER;
         spinner.valign = Gtk.Align.CENTER;
-        spinner.start ();
 
         var welcome = new Granite.Widgets.Welcome (_("Select Table"), _("Select a table from the left sidebar to activate this view."));
 
@@ -96,10 +95,12 @@ public class Sequeler.Layouts.Views.Structure : Gtk.Grid {
     }
 
     public void start_spinner () {
+        spinner.start ();
         stack.visible_child_name = "spinner";
     }
 
     public void stop_spinner () {
+        spinner.stop ();
         stack.visible_child_name = "list";
     }
 


### PR DESCRIPTION
This cuts down on CPU usage when the application is idle.

Even when doing nothing, sequeler uses 1% to 2% CPU on my machine. On laptops this will prevent the CPU from going into idle states.

This happens when any part of the sequeler window is exposed.

I narrowed the CPU usage down to GTK spinners. It seems that the spinner animation is running even when the spinner is not visible.

This PR starts and stops spinners instead of letting them run all the time.