### PR TITLE
CI: update flatpak job

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -12,7 +12,7 @@ jobs:
       options: --privileged
     steps:
       - uses: actions/checkout@v2
-      - uses: bilelmoussaoui/flatpak-github-actions@master
+      - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@master
         with:
           bundle: "sequeler-nightly.flatpak"
           manifest-path: "build-aux/com.github.alecaddd.sequeler.json"


### PR DESCRIPTION

the repository now hosts two extensions:
- flatpak-builder: for building and deploying an artifact
- flat-manager: for uploading the artifact to a remote repository (like the elemntary one in the future)

this pr changes the CI according to the upstream changes