### PR TITLE
Granite version should be >=5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you like Sequeler and you want to support its development, consider donating 
 ## Install it from source
 You can install Sequeler by compiling from source, here's the list of dependencies required:
  - `gtk+-3.0>=3.22.29`
- - `granite>=5.2`
+ - `granite>=5.3`
  - `glib-2.0`
  - `gee-0.8`
  - `gobject-2.0`

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,7 +55,7 @@ executable(
     config_header,
     dependencies: [
         dependency('gtk+-3.0'),
-        dependency('granite', version: '>= 0.5.1'),
+        dependency('granite', version: '>= 5.3.0'),
         dependency('glib-2.0'),
         dependency('gee-0.8'),
         dependency('gobject-2.0'),


### PR DESCRIPTION
#346 
[Granite v5.2](https://github.com/elementary/granite/tree/5.2.0/lib/Widgets) does not have `AccelLabel`, and [v5.3](https://github.com/elementary/granite/tree/5.3.0/lib/Widgets) has it!