### PR TITLE
Flatpak: Update modules

### DIFF
--- a/build-aux/io.github.ellie_commons.sequeler.json
+++ b/build-aux/io.github.ellie_commons.sequeler.json
@@ -142,6 +142,7 @@
             "-DWITH_INNOBASE_STORAGE_ENGINE=1",
             "-DWITH_PCRE=system",
             "-DWITH_LIBFMT=system",
+            "-DWITH_SBOM=0",
             "-DWITHOUT_ARCHIVE_STORAGE_ENGINE=1",
             "-DWITHOUT_BLACKHOLE_STORAGE_ENGINE=1",
             "-DWITHOUT_PARTITION_STORAGE_ENGINE=1",

--- a/io.github.ellie_commons.sequeler.json
+++ b/io.github.ellie_commons.sequeler.json
@@ -139,6 +139,7 @@
             "-DWITH_INNOBASE_STORAGE_ENGINE=1",
             "-DWITH_PCRE=system",
             "-DWITH_LIBFMT=system",
+            "-DWITH_SBOM=0",
             "-DWITHOUT_ARCHIVE_STORAGE_ENGINE=1",
             "-DWITHOUT_BLACKHOLE_STORAGE_ENGINE=1",
             "-DWITHOUT_PARTITION_STORAGE_ENGINE=1",


### PR DESCRIPTION
Rebased merge is designed.

- Update modules
    - Update jemalloc to 5.3.0
    - Update fmt to 12.1.0
    - Update libssh2 to 1.11.1
    - Update libfixposix to 0.5.1
    - Update postgresql to 18.1
    - Update mariadb to 12.2.1
- mariadb: Disable SBOM to fix build error
    - See the commit message for build error details

## Checklist
- [x] Building and installation succeeds with `flatpak-builder builddir build-aux/com.github.alecaddd.sequeler.json --force-clean --install --user --install-deps-from=flathub`
- [x]  Building and installation succeeds with `flatpak-builder builddir com.github.alecaddd.sequeler.json --force-clean --install --user --install-deps-from=appcenter`
- [x] The app launches
- [x] Can manage DB on MySQL
- [x] Can manage DB on PostgreSQL
- [x] Can manage DB on MariaDB
