### PR TITLE
Re-RDNN development build for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo ninja -C build install
 
 You can run the application from terminal using
 ```
-io.github.ellie_commons.sequelerDevel
+io.github.ellie_commons.sequeler.Devel
 ```
 
 ### Help with the translation

--- a/data/assets/icons/128x128/io.github.ellie_commons.sequeler.Devel.svg
+++ b/data/assets/icons/128x128/io.github.ellie_commons.sequeler.Devel.svg
@@ -15,7 +15,7 @@
    height="128"
    id="svg4434"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="io.github.ellie_commons.sequelerDevel.svg"
+   sodipodi:docname="io.github.ellie_commons.sequeler.Devel.svg"
    inkscape:export-filename="/home/alecaddd/Pictures/sequeler-devel.png"
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96">

--- a/data/assets/icons/16x16/io.github.ellie_commons.sequeler.Devel.svg
+++ b/data/assets/icons/16x16/io.github.ellie_commons.sequeler.Devel.svg
@@ -13,7 +13,7 @@
    height="16"
    id="svg4372"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="io.github.ellie_commons.sequelerDevel.svg">
+   sodipodi:docname="io.github.ellie_commons.sequeler.Devel.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"

--- a/data/assets/icons/24x24/io.github.ellie_commons.sequeler.Devel.svg
+++ b/data/assets/icons/24x24/io.github.ellie_commons.sequeler.Devel.svg
@@ -13,7 +13,7 @@
    width="24"
    version="1.1"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="io.github.ellie_commons.sequelerDevel.svg">
+   sodipodi:docname="io.github.ellie_commons.sequeler.Devel.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"

--- a/data/assets/icons/32x32/io.github.ellie_commons.sequeler.Devel.svg
+++ b/data/assets/icons/32x32/io.github.ellie_commons.sequeler.Devel.svg
@@ -13,7 +13,7 @@
    width="32"
    version="1.1"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="io.github.ellie_commons.sequelerDevel.svg">
+   sodipodi:docname="io.github.ellie_commons.sequeler.Devel.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"

--- a/data/assets/icons/48x48/io.github.ellie_commons.sequeler.Devel.svg
+++ b/data/assets/icons/48x48/io.github.ellie_commons.sequeler.Devel.svg
@@ -13,7 +13,7 @@
    width="48"
    version="1.1"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="io.github.ellie_commons.sequelerDevel.svg">
+   sodipodi:docname="io.github.ellie_commons.sequeler.Devel.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"

--- a/data/assets/icons/64x64/io.github.ellie_commons.sequeler.Devel.svg
+++ b/data/assets/icons/64x64/io.github.ellie_commons.sequeler.Devel.svg
@@ -13,7 +13,7 @@
    height="64px"
    width="64px"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   sodipodi:docname="io.github.ellie_commons.sequelerDevel.svg">
+   sodipodi:docname="io.github.ellie_commons.sequeler.Devel.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"

--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@ add_project_arguments(
 )
 
 if get_option('profile') == 'development'
-	application_id = '@0@Devel'.format(meson.project_name())
+	application_id = '@0@.Devel'.format(meson.project_name())
 	vala_args += ['-D', 'IS_DEVEL']
 else
 	application_id = meson.project_name()


### PR DESCRIPTION
GNOME apps often uses `xxx.yyy.Devel` RDNN instead of `xxx.yyyDevel`
