### PR TITLE
Flatpak: Do not cleanup /lib/debug

### DIFF
--- a/build-aux/io.github.ellie_commons.sequeler.yml
+++ b/build-aux/io.github.ellie_commons.sequeler.yml
@@ -16,7 +16,6 @@ finish-args:
 cleanup:
   - /include
   - /lib/pkgconfig
-  - /lib/debug
   - /share/vala
   - /man
   - '*.a'

--- a/io.github.ellie_commons.sequeler.yml
+++ b/io.github.ellie_commons.sequeler.yml
@@ -13,7 +13,6 @@ finish-args:
 cleanup:
   - /include
   - /lib/pkgconfig
-  - /lib/debug
   - /share/vala
   - /man
   - '*.a'


### PR DESCRIPTION
From https://docs.flathub.org/docs/for-app-authors/linter#toplevel-cleanup-debug

    toplevel-cleanup-debug
    The toplevel cleanup property in the Flatpak manifest has /lib/debug or a subdirectory of it.
    This must not be cleaned up as it is used to generate debug data for the Flatpak by Flatpak Builder.

## Checklist
- [x] `flatpak-builder-lint` no longer report `toplevel-cleanup-debug` error (see below for details)
- [x]  Building and installation succeeds with `flatpak-builder builddir com.github.alecaddd.sequeler.yml --force-clean --install --user --install-deps-from=appcenter`
- [x] The app launches

### Before
```
user@elementary-daily:~/work/tmp/sequeler (main =)$ flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest build-aux/io.github.ellie_commons.sequeler.yml
{
    "errors": [
        "finish-args-has-socket-ssh-auth",
        "finish-args-ssh-filesystem-access",
        "toplevel-cleanup-debug"
    ],
    "message": "See https://docs.flathub.org/linter for details and exceptions"
}
[ble: exit 1]
user@elementary-daily:~/work/tmp/sequeler (main =)$
```

### After
```
user@elementary-daily:~/work/tmp/sequeler (ryonakano/flatpak-linter-toplevel-cleanup-debug)$ flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest build-aux/io.github.ellie_commons.sequeler.yml
{
    "errors": [
        "finish-args-has-socket-ssh-auth",
        "finish-args-ssh-filesystem-access"
    ],
    "message": "See https://docs.flathub.org/linter for details and exceptions"
}
[ble: exit 1]
user@elementary-daily:~/work/tmp/sequeler (ryonakano/flatpak-linter-toplevel-cleanup-debug)$
```