### PR TITLE
Add option to disable installing the sized app icon

### DIFF
--- a/build-aux/io.github.ellie_commons.sequeler.yml
+++ b/build-aux/io.github.ellie_commons.sequeler.yml
@@ -185,6 +185,9 @@ modules:
 
   - name: sequeler
     buildsystem: meson
+    build-options:
+      config-opts:
+        - -Dsized-app-icon=false
     sources:
       - type: dir
         path: ../

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,23 +1,25 @@
-icon_sizes = ['16', '24', '32', '48', '64', '128']
-
 icons_dir = join_paths(get_option('datadir'), 'icons', 'hicolor')
-foreach size : icon_sizes
-		asset = join_paths('assets', 'icons', '@0@x@0@'.format(size), '@0@.svg'.format(application_id))
-		install_data(
-				asset,
-				install_dir:  join_paths(icons_dir, '@0@x@0@'.format(size), 'apps')
-		)
-		install_data(
-				asset,
-				install_dir: join_paths(icons_dir,  '@0@x@0@@2'.format(size), 'apps')
-		)
-endforeach
 
-install_data(
-		join_paths('assets', 'icons', '128x128', '@0@.svg'.format(application_id)),
-		install_dir: join_paths(icons_dir , 'scalable', 'apps'),
-		rename: '@0@.svg'.format(application_id)
-)
+if get_option('sized-app-icon')
+	icon_sizes = ['16', '24', '32', '48', '64', '128']
+	foreach size : icon_sizes
+			asset = join_paths('assets', 'icons', '@0@x@0@'.format(size), '@0@.svg'.format(application_id))
+			install_data(
+					asset,
+					install_dir:  join_paths(icons_dir, '@0@x@0@'.format(size), 'apps')
+			)
+			install_data(
+					asset,
+					install_dir: join_paths(icons_dir,  '@0@x@0@@2'.format(size), 'apps')
+			)
+	endforeach
+else
+	install_data(
+			join_paths('assets', 'icons', '128x128', '@0@.svg'.format(application_id)),
+			install_dir: join_paths(icons_dir , 'scalable', 'apps'),
+			rename: '@0@.svg'.format(application_id)
+	)
+endif
 
 install_data(
 		join_paths('assets', 'icons', 'status', 'table.svg'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,3 +7,4 @@ option(
         ],
         value: 'default'
 )
+option('sized-app-icon', type: 'boolean', value: true)


### PR DESCRIPTION
Fixes #419

## Checklist
- [x] `flatpak-builder-lint` no longer report `non-png-icon-in-hicolor-size-folder` error (see below for details)

### Before
Run `flatpak run --command=flathub-build org.flatpak.Builder --install io.github.ellie_commons.sequeler.yml` then run the following command:

```
user@elementary:~/work/ellie-commons/sequeler (main *%=)$ flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
{
    "errors": [
        "appstream-missing-screenshots",
        "finish-args-ssh-filesystem-access",
        "non-png-icon-in-hicolor-size-folder",
        "finish-args-has-socket-ssh-auth"
    ],
    "info": [
        "appstream-missing-screenshots: Catalogue file has no screenshots. Please check if screenshot URLs are reachable",
        "non-png-icon-in-hicolor-size-folder: ['/tmp/tmpqfa8_koc/icons/hicolor/64x64@2/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/64x64/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/48x48@2/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/48x48/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/32x32@2/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/32x32/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/24x24@2/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/24x24/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/16x16@2/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/16x16/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/128x128@2/apps/io.github.ellie_commons.sequeler.svg', '/tmp/tmpqfa8_koc/icons/hicolor/128x128/apps/io.github.ellie_commons.sequeler.svg']"
    ],
    "message": "See https://docs.flathub.org/linter for details and exceptions"
}
[ble: exit 1]
user@elementary:~/work/ellie-commons/sequeler (main *%=)$
```

### After
```
user@elementary:~/work/ellie-commons/sequeler (ryonakano/flatpak-linter-non-svg-icon-in-scalable-folder *%)$ flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
{
    "errors": [
        "finish-args-has-socket-ssh-auth",
        "finish-args-ssh-filesystem-access",
        "appstream-missing-screenshots"
    ],
    "info": [
        "appstream-missing-screenshots: Catalogue file has no screenshots. Please check if screenshot URLs are reachable"
    ],
    "message": "See https://docs.flathub.org/linter for details and exceptions"
}
[ble: exit 1]
user@elementary:~/work/ellie-commons/sequeler (ryonakano/flatpak-linter-non-svg-icon-in-scalable-folder *%)$
```