### PR TITLE
Remove unnecessary --socket=ssh-auth permission

### DIFF
--- a/build-aux/io.github.ellie_commons.sequeler.yml
+++ b/build-aux/io.github.ellie_commons.sequeler.yml
@@ -11,7 +11,6 @@ finish-args:
   - --socket=wayland
   - --talk-name=org.freedesktop.secrets
   - --share=network
-  - --socket=ssh-auth
 cleanup:
   - /include
   - /lib/pkgconfig

--- a/io.github.ellie_commons.sequeler.yml
+++ b/io.github.ellie_commons.sequeler.yml
@@ -8,7 +8,6 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --share=network
-  - --socket=ssh-auth
 cleanup:
   - /include
   - /lib/pkgconfig


### PR DESCRIPTION
Backport of https://github.com/flathub/flathub/pull/7405/changes/1cf104fb37a886a22905a1cb10e16ff2a16bb99c, which I found while submission for Flathub.

---

We surely provide the feature to connect to DB through a SSH tunnel, but this seems to be possible without --socket=ssh-auth permission.

According to https://docs.flatpak.org/en/latest/sandbox-permissions.html, this seems to be only needed when using ssh-agent from inside of the sandbox:

    --socket=ssh-auth- Allow access to $SSH_AUTH_SOCK. This is not commonly
    needed unless the application interacts with SSH such as Git clients or
    SSH frontends.

However, we don't use any classes/methods that related to ssh-agent, e.g. `SSH2.Agent`:

```
user@elementary:~/work/ellie-commons/sequeler (ryonakano/flatpak-remove-ssh-permission $)$ git grep -n SSH2 -- src
src/Services/ConnectionManager.vala:38:    public SSH2.Session session;
src/Services/ConnectionManager.vala:193:        var rc = SSH2.init (0);
src/Services/ConnectionManager.vala:194:        if (rc != SSH2.Error.NONE) {
src/Services/ConnectionManager.vala:218:        session = SSH2.Session.create<bool> ();
src/Services/ConnectionManager.vala:224:        if (rc != SSH2.Error.NONE) {
src/Services/ConnectionManager.vala:242:            if (session.auth_password (username, password) != SSH2.Error.NONE) {
src/Services/ConnectionManager.vala:252:                                            ) != SSH2.Error.NONE) {
src/Services/ConnectionManager.vala:378:                    if (SSH2.Error.AGAIN == len)
src/Services/ConnectionManager.vala:397:                    if (channel.eof () != SSH2.Error.NONE) {
src/Services/ConnectionManager.vala:431:        SSH2.exit ();
user@elementary:~/work/ellie-commons/sequeler (ryonakano/flatpak-remove-ssh-permission $)$
```

Rather, using this permission on Flathub requires apply for exception, so let's remove it as unnecessary.

https://docs.flathub.org/docs/for-app-authors/linter#finish-args-has-socket-ssh-auth

---

## Checklist
- [x]  Building and installation succeeds with flatpak-builder builddir com.github.alecaddd.sequeler.json --force-clean --install --user --install-deps-from=appcenter
- [x] Can connect to an DB through a SSH tunnel
