### PR TITLE
Flatpak: mariadb: Build with system OpenSSL instead of bundled wolfSSL

### DIFF
--- a/build-aux/io.github.ellie_commons.sequeler.yml
+++ b/build-aux/io.github.ellie_commons.sequeler.yml
@@ -127,6 +127,7 @@ modules:
           - -DWITH_INNOBASE_STORAGE_ENGINE=1
           - -DWITH_PCRE=system
           - -DWITH_LIBFMT=system
+          - -DWITH_SSL=system
           - -DWITH_SBOM=0
           - -DWITHOUT_ARCHIVE_STORAGE_ENGINE=1
           - -DWITHOUT_BLACKHOLE_STORAGE_ENGINE=1

--- a/io.github.ellie_commons.sequeler.yml
+++ b/io.github.ellie_commons.sequeler.yml
@@ -123,6 +123,7 @@ modules:
           - -DWITH_INNOBASE_STORAGE_ENGINE=1
           - -DWITH_PCRE=system
           - -DWITH_LIBFMT=system
+          - -DWITH_SSL=system
           - -DWITH_SBOM=0
           - -DWITHOUT_ARCHIVE_STORAGE_ENGINE=1
           - -DWITHOUT_BLACKHOLE_STORAGE_ENGINE=1


### PR DESCRIPTION
I suppose this may shrink build time a little.

| | Build Time |
| -- | -- |
| Before: with bundled wolfSSL | [17m 15s](https://github.com/ellie-commons/sequeler/actions/runs/20523833037/job/58963564367) |
| After: with system OpenSSL | [16m 56s](https://github.com/ellie-commons/sequeler/actions/runs/20536814430/job/58996093960?pr=435) |
