### PR TITLE
Application: Use Vala-style properties

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -121,8 +121,8 @@ public class Sequeler.Application : Gtk.Application {
         unowned string desktop_environment = Environment.get_variable ("XDG_CURRENT_DESKTOP");
         if (desktop_environment != "Pantheon") {
             // Force elementary stylesheet to prevent broken UI on other DEs
-            gtk_settings.set_property ("gtk-theme-name", "elementary");
-            gtk_settings.set_property ("gtk-icon-theme-name", "elementary");
+            gtk_settings.gtk_theme_name = "elementary";
+            gtk_settings.gtk_icon_theme_name = "elementary";
         }
     }
 


### PR DESCRIPTION
Addresses the suggestion in https://github.com/ellie-commons/sequeler/pull/436#discussion_r2649198858

Tested elementary theme and icon theme are still used if `XDG_CURRENT_DESKTOP` is not Pantheon.
